### PR TITLE
Check that AWS_SESSION_TOKEN is set in our scripts

### DIFF
--- a/bin/dalmatian-container-access
+++ b/bin/dalmatian-container-access
@@ -71,6 +71,15 @@ echo "==> Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure
 
 eval "$("$SCRIPT_PATH/dalmatian-assume-infrastructure-role" -i "$INFRASTRUCTURE_NAME" -p "$AWS_PROFILE")"
 
+# Check that eval set AWS_SESSION_TOKEN if not exit and provide some clues as to why not
+if [[ -z $AWS_SESSION_TOKEN ]]
+then
+  echo "AWS_SESSION_TOKEN not set by $SCRIPT_PATH/dalmatian-assume-infrastructure-role -i $INFRASTRUCTURE_NAME -p $AWS_PROFILE."
+  echo "Have you run dalmatian-mfa recently?"
+  echo "Can you clone git@github.com:dxw/dalmatian-config?"
+  exit 1
+fi
+
 echo "==> Finding container..."
 
 CLUSTER="$INFRASTRUCTURE_NAME-$ENVIRONMENT"

--- a/bin/dalmatian-ec2-access
+++ b/bin/dalmatian-ec2-access
@@ -66,6 +66,15 @@ echo "==> Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure
 
 eval "$("$SCRIPT_PATH/dalmatian-assume-infrastructure-role" -i "$INFRASTRUCTURE_NAME" -p "$AWS_PROFILE")"
 
+# Check that eval set AWS_SESSION_TOKEN if not exit and provide some clues as to why not
+if [[ -z $AWS_SESSION_TOKEN ]]
+then
+  echo "AWS_SESSION_TOKEN not set by $SCRIPT_PATH/dalmatian-assume-infrastructure-role -i $INFRASTRUCTURE_NAME -p $AWS_PROFILE."
+  echo "Have you run dalmatian-mfa recently?"
+  echo "Can you clone git@github.com:dxw/dalmatian-config?"
+  exit 1
+fi
+
 echo "==> Finding ECS instance..."
 
 INSTANCES=$(aws ec2 describe-instances --filters Name=instance-state-code,Values=16 Name=tag:Name,Values="$INFRASTRUCTURE_NAME-$ENVIRONMENT*")

--- a/bin/dalmatian-file-upload
+++ b/bin/dalmatian-file-upload
@@ -85,6 +85,15 @@ echo "==> Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure
 
 eval "$("$SCRIPT_PATH/dalmatian-assume-infrastructure-role" -i "$INFRASTRUCTURE_NAME" -p "$AWS_PROFILE")"
 
+# Check that eval set AWS_SESSION_TOKEN if not exit and provide some clues as to why not
+if [[ -z $AWS_SESSION_TOKEN ]]
+then
+  echo "AWS_SESSION_TOKEN not set by $SCRIPT_PATH/dalmatian-assume-infrastructure-role -i $INFRASTRUCTURE_NAME -p $AWS_PROFILE."
+  echo "Have you run dalmatian-mfa recently?"
+  echo "Can you clone git@github.com:dxw/dalmatian-config?"
+  exit 1
+fi
+
 echo "==> Copying to $BUCKET_NAME S3 bucket ..."
 
 if [ "$RECURSIVE" == 1 ];

--- a/bin/dalmatian-rds-create-database
+++ b/bin/dalmatian-rds-create-database
@@ -80,6 +80,15 @@ echo "==> Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure
 
 eval "$("$SCRIPT_PATH/dalmatian-assume-infrastructure-role" -i "$INFRASTRUCTURE_NAME" -p "$AWS_PROFILE")"
 
+# Check that eval set AWS_SESSION_TOKEN if not exit and provide some clues as to why not
+if [[ -z $AWS_SESSION_TOKEN ]]
+then
+  echo "AWS_SESSION_TOKEN not set by $SCRIPT_PATH/dalmatian-assume-infrastructure-role -i $INFRASTRUCTURE_NAME -p $AWS_PROFILE."
+  echo "Have you run dalmatian-mfa recently?"
+  echo "Can you clone git@github.com:dxw/dalmatian-config?"
+  exit 1
+fi
+
 echo "==> Retrieving RDS root password from Parameter Store..."
 
 RDS_ROOT_PASSWORD_PARAMETER=$(

--- a/bin/dalmatian-rds-export-dump
+++ b/bin/dalmatian-rds-export-dump
@@ -81,6 +81,15 @@ echo "==> Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure
 
 eval "$("$SCRIPT_PATH/dalmatian-assume-infrastructure-role" -i "$INFRASTRUCTURE_NAME" -p "$AWS_PROFILE")"
 
+# Check that eval set AWS_SESSION_TOKEN if not exit and provide some clues as to why not
+if [[ -z $AWS_SESSION_TOKEN ]]
+then
+  echo "AWS_SESSION_TOKEN not set by $SCRIPT_PATH/dalmatian-assume-infrastructure-role -i $INFRASTRUCTURE_NAME -p $AWS_PROFILE."
+  echo "Have you run dalmatian-mfa recently?"
+  echo "Can you clone git@github.com:dxw/dalmatian-config?"
+  exit 1
+fi
+
 echo "==> Retrieving RDS root password from Parameter Store..."
 
 RDS_ROOT_PASSWORD_PARAMETER=$(

--- a/bin/dalmatian-rds-import-dump
+++ b/bin/dalmatian-rds-import-dump
@@ -82,6 +82,15 @@ echo "==> Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure
 
 eval "$("$SCRIPT_PATH/dalmatian-assume-infrastructure-role" -i "$INFRASTRUCTURE_NAME" -p "$AWS_PROFILE")"
 
+# Check that eval set AWS_SESSION_TOKEN if not exit and provide some clues as to why not
+if [[ -z $AWS_SESSION_TOKEN ]]
+then
+  echo "AWS_SESSION_TOKEN not set by $SCRIPT_PATH/dalmatian-assume-infrastructure-role -i $INFRASTRUCTURE_NAME -p $AWS_PROFILE."
+  echo "Have you run dalmatian-mfa recently?"
+  echo "Can you clone git@github.com:dxw/dalmatian-config?"
+  exit 1
+fi
+
 echo "==> Retrieving RDS root password from Parameter Store..."
 
 RDS_ROOT_PASSWORD_PARAMETER=$(

--- a/bin/dalmatian-rds-shell
+++ b/bin/dalmatian-rds-shell
@@ -65,6 +65,15 @@ echo "==> Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure
 
 eval "$("$SCRIPT_PATH/dalmatian-assume-infrastructure-role" -i "$INFRASTRUCTURE_NAME" -p "$AWS_PROFILE")"
 
+# Check that eval set AWS_SESSION_TOKEN if not exit and provide some clues as to why not
+if [[ -z $AWS_SESSION_TOKEN ]]
+then
+  echo "AWS_SESSION_TOKEN not set by $SCRIPT_PATH/dalmatian-assume-infrastructure-role -i $INFRASTRUCTURE_NAME -p $AWS_PROFILE."
+  echo "Have you run dalmatian-mfa recently?"
+  echo "Can you clone git@github.com:dxw/dalmatian-config?"
+  exit 1
+fi
+
 echo "==> Retrieving RDS root password from Parameter Store..."
 
 RDS_ROOT_PASSWORD_PARAMETER=$(


### PR DESCRIPTION
Add a check to make sure that `eval
"$("$SCRIPT_PATH/dalmatian-assume-infrastructure-role" -i
"$INFRASTRUCTURE_NAME" -p "$AWS_PROFILE")"` sets AWS_SESSION_TOKEN

`eval` does not error if it is passed nothing to evaluate which can happen if the
the script being called in `$()` fails. `eval` will only pass up an error code if
if it used like `eval /path/to/script`. This form of calling however doesn't
then run export to set the AWS environment variables that the rest of the
script needs to be set.

The `dalmatian-assume-infrastructure-role` script can fail if dalmatian-mfa
hasn't been run recently or the clone of the dalmatian-config repo fails.
We add checking those as suggestions for the user.

This fixes #22