### PR TITLE
Install coreutils

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
 brew "awscli"
 brew "jq"
 brew "yq"
+brew "coreutils"


### PR DESCRIPTION
We use realpath which is provided by coreutils.
This used to be available in MacOSX but seems to have gone away.