### PR TITLE
GPG can decrypt saved credentials

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -163,7 +163,6 @@ fi
 # Update MFA credentials if needed, or if the dalmatian aws mfa command is ran
 if [[ -n "$RUN_AWS_MFA" || "$MFA_CONFIGURED" == 0 ]]
 then
-  DALMATIAN_CREDENTIALS_FILE="$DALMATIAN_CREDENTIALS_FILE.enc"
   DALMATIAN_CREDENTIALS_JSON_STRING=$(
     gpg --decrypt \
       --quiet \
@@ -207,7 +206,7 @@ then
   fi
 fi
 
-# Update assume role credentials if needed 
+# Update assume role credentials if needed
 if [ "$ASSUME_MAIN_ROLE_CONFIGURED" == "0" ]
 then
   echo "==> Requesting Assume Role credentials ..."


### PR DESCRIPTION
The `DALMATIAN_CREDENTIALS_FILE ` variable is already defined on line 123 [1]. This code was creating a new variable for the same filepath but suffixing an extra `.enc` on the end. The file `credentials.json.enc.enc` is never created so removing this extra step allows credentials to be read.

[1] https://github.com/dxw/dalmatian-tools/blob/ff79698fb65f6c58bd0937ffc7544fd70b603532/bin/dalmatian#L123

![Screenshot 2020-11-06 at 10 27 50](https://user-images.githubusercontent.com/912473/98356710-ee59cb00-201b-11eb-8dc2-d27220b0c9b0.png)
