### PR TITLE
Add a sub command to download cloudfront logs

### DIFF
--- a/bin/cloudfront/logs
+++ b/bin/cloudfront/logs
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -s <service_name>      - service name"
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  echo "  -p <pattern>           - pattern to include [Optional] (e.g. '2020-11-13')"
+  echo "  -d <directory>         - directory to download logs to [Optional] (e.g /home/user/logs/)"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -eq 0 ]
+then
+ usage
+ exit 0
+fi
+
+
+while getopts "i:e:s:p:d:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    s)
+      SERVICE_NAME=$OPTARG
+      ;;
+    p)
+      PATTERN=$OPTARG
+      ;;
+    d)
+      DIRECTORY=$OPTARG
+      ;;
+    h)
+      usage
+      exit;;
+    *)
+      usage
+      exit;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$ENVIRONMENT"
+  || -z "$SERVICE_NAME"
+]]
+then
+  usage
+fi
+
+if [[ -z "$DIRECTORY" ]]
+then
+  DIRECTORY=/tmp/$INFRASTRUCTURE_NAME-$SERVICE_NAME-$ENVIRONMENT-cloudfront-logs
+fi
+
+echo "---> making sure $DIRECTORY exists"
+mkdir -p "$DIRECTORY"
+
+
+echo "---> downloading log files"
+if [[ -z "$PATTERN" ]]
+then
+  aws s3 sync s3://"${INFRASTRUCTURE_NAME}"-"${SERVICE_NAME}"-"${ENVIRONMENT}"-cloudfront-logs/ "$DIRECTORY"
+else
+  aws s3 sync s3://"${INFRASTRUCTURE_NAME}"-"${SERVICE_NAME}"-"${ENVIRONMENT}"-cloudfront-logs/ "$DIRECTORY" --exclude "*" --include "*${PATTERN}*"
+fi
+
+echo "logs in /tmp/${INFRASTRUCTURE_NAME}-${SERVICE_NAME}-${ENVIRONMENT}-cloudfront-logs/"


### PR DESCRIPTION
When investigating an incident it is helpful to have a local copy of the logs
to generate some numbers about what happened during the incident.

This script replicates the actions mentioned in https://git.govpress.com/ops/docs/-/blob/8bf6fcc32b0251508eeb35637751c0ebabc8d89b/getting-cloudfront-logs.md