### PR TITLE
Fix output of cloudfront logs command.

### DIFF
--- a/bin/cloudfront/logs
+++ b/bin/cloudfront/logs
@@ -63,11 +63,11 @@ then
   DIRECTORY=/tmp/$INFRASTRUCTURE_NAME-$SERVICE_NAME-$ENVIRONMENT-cloudfront-logs
 fi
 
-echo "---> making sure $DIRECTORY exists"
+echo "==> making sure $DIRECTORY exists"
 mkdir -p "$DIRECTORY"
 
 
-echo "---> downloading log files"
+echo "==> downloading log files"
 if [[ -z "$PATTERN" ]]
 then
   aws s3 sync s3://"${INFRASTRUCTURE_NAME}"-"${SERVICE_NAME}"-"${ENVIRONMENT}"-cloudfront-logs/ "$DIRECTORY"
@@ -75,4 +75,4 @@ else
   aws s3 sync s3://"${INFRASTRUCTURE_NAME}"-"${SERVICE_NAME}"-"${ENVIRONMENT}"-cloudfront-logs/ "$DIRECTORY" --exclude "*" --include "*${PATTERN}*"
 fi
 
-echo "logs in /tmp/${INFRASTRUCTURE_NAME}-${SERVICE_NAME}-${ENVIRONMENT}-cloudfront-logs/"
+echo "==> logs in ${DIRECTORY}"


### PR DESCRIPTION
- be consistent with what text arrow we use
- output which directory the logs were put in correctly