### PR TITLE
Rename completion alias to not appear in tab complete

### DIFF
--- a/support/bash-completion.sh
+++ b/support/bash-completion.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-dalmatian_completion() {
+_dalmatian_completion() {
   if ! command -v dalmatian > /dev/null
   then
     return 0
@@ -74,4 +74,4 @@ dalmatian_completion() {
     fi
   fi
 }
-complete -F dalmatian_completion dalmatian
+complete -F _dalmatian_completion dalmatian


### PR DESCRIPTION
Most completion aliases start with `_` so they don't pollute the completion of
the main command.
Before:

```
 $  dalmatian
dalmatian                 dalmatian-refresh-config
dalmatian-bob-mfa.sh      dalmatian_completion
```

After:

```
$  dalmatian
dalmatian                 dalmatian-bob-mfa.sh      dalmatian-refresh-config
```