### PR TITLE
Add commands to list environments, infrastructures and services

### DIFF
--- a/bin/config/list-environments
+++ b/bin/config/list-environments
@@ -1,0 +1,21 @@
+#!/bin/bash
+"$APP_ROOT/bin/dalmatian-refresh-config" > /dev/null
+usage() {
+  echo "List environment names (e.g. 'staging' or 'prod') for an infrastructure"
+  echo "Usage: $(basename "$0") <infrastructure name [OPTIONAL]>" 1>&2
+  echo "  -h                     - help"
+  exit 1
+}
+INFRASTRUCTURE_NAME="${1:-*}"
+while getopts "h" opt; do
+  case $opt in
+    h)
+      usage
+      exit;;
+    *)
+      usage
+      exit;;
+  esac
+done
+
+yq r --printMode p "$APP_ROOT/bin/tmp/dalmatian-config/dalmatian.yml" "infrastructures.$INFRASTRUCTURE_NAME.environments.*" | awk -F. '{print $2": "$4}'

--- a/bin/config/list-infrastructures
+++ b/bin/config/list-infrastructures
@@ -1,0 +1,20 @@
+#!/bin/bash
+"$APP_ROOT/bin/dalmatian-refresh-config" > /dev/null
+
+usage() {
+  echo "List all infrastructures"
+  echo "Usage: $(basename "$0")" 1>&2
+  echo "  -h                     - help"
+  exit 1
+}
+while getopts "h" opt; do
+  case $opt in
+    h)
+      usage
+      exit;;
+    *)
+      usage
+      exit;;
+  esac
+done
+yq r --printMode p "$APP_ROOT/bin/tmp/dalmatian-config/dalmatian.yml" infrastructures.* | sed 's/infrastructures.//g'

--- a/bin/config/list-services
+++ b/bin/config/list-services
@@ -1,0 +1,21 @@
+#!/bin/bash
+"$APP_ROOT/bin/dalmatian-refresh-config" > /dev/null
+usage() {
+  echo "List all services or list services for an infrastructure"
+  echo "Usage: $(basename "$0") <infrastructure name [OPTIONAL]>" 1>&2
+  echo "  -h                     - help"
+  exit 1
+}
+INFRASTRUCTURE_NAME="${1:-*}"
+while getopts "h" opt; do
+  case $opt in
+    h)
+      usage
+      exit;;
+    *)
+      usage
+      exit;;
+  esac
+done
+
+yq r --printMode pv "$APP_ROOT/bin/tmp/dalmatian-config/dalmatian.yml" "infrastructures.$INFRASTRUCTURE_NAME.services.[*].name" | awk -F. '{print $2 $5}' | sed  's/name: /: /g'


### PR DESCRIPTION
While YAML is human readable we should help people to understand what
environments, infrastructures and services exist in the cofiguration without
them needing to understand the layout of the YAML.