### PR TITLE
Add service restart-containers script

### DIFF
--- a/bin/service/restart-containers
+++ b/bin/service/restart-containers
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -s <service>           - service name "
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ]
+then
+ usage
+fi
+
+while getopts "i:e:s:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    s)
+      SERVICE_NAME=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$SERVICE_NAME"
+  || -z "$ENVIRONMENT"
+]]
+then
+  usage
+fi
+
+echo "==> restarting containers for $SERVICE_NAME in $ENVIRONMENT"
+
+DEPLOYMENT=$(aws ecs update-service --service "$SERVICE_NAME" --task-definition "$ENVIRONMENT-$INFRASTRUCTURE_NAME-$SERVICE_NAME" --cluster "$INFRASTRUCTURE_NAME-$ENVIRONMENT" --force-new-deployment)
+EVENT_ID_REGEX=$(echo "$DEPLOYMENT" | jq -r '.service.events[] | .id' | tr '\n' '|' | sed 's/.$//')
+DEPLOYMENT_ID=$(echo "$DEPLOYMENT" | jq -r '.service.deployments[] | select(.status == "PRIMARY") | .id')
+STATUS=""
+while [ "$STATUS" != "COMPLETED" ]
+do
+  SERVICE=$(aws ecs describe-services --cluster "$INFRASTRUCTURE_NAME-$ENVIRONMENT" --services "$SERVICE_NAME")
+  EVENTS=$(echo "$SERVICE" | jq -r --arg r "$EVENT_ID_REGEX" '.services[0].events[] | select(.id | test("\($r)") | not)')
+  EVENT_ID_REGEX=$(echo "$SERVICE" | jq -r '.services[0].events[] | .id' | tr '\n' '|' | sed 's/.$//')
+  STATUS=$(echo "$SERVICE" | jq -r --arg i "$DEPLOYMENT_ID" '.services[0].deployments[] | select(.id == $i) | .rolloutState')
+  if [ -n "$EVENTS" ]
+  then
+    echo "$EVENTS" | jq -r '.message'
+  fi
+  echo "$SERVICE" | jq -r --arg i "$DEPLOYMENT_ID" '.services[0].deployments[] | select(.id == $i) | "\(.rolloutState) - Desired: \(.desiredCount), Pending: \(.pendingCount), Running: \(.runningCount)"'
+  sleep 10
+done


### PR DESCRIPTION
* Forces a deployemnt of a given service
* Provides a faster way to restart the containers after adding an
  environment variable, rather than running a full CodePipeline run with
  the service deploy script