### PR TITLE
Use jq to sort environment variables instead of `sort`

### DIFF
--- a/bin/service/list-environment-variables
+++ b/bin/service/list-environment-variables
@@ -54,6 +54,5 @@ aws ssm get-parameters-by-path \
   --path "/$INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT/" \
   --recursive \
   --with-decryption \
-  | jq -r '.Parameters[] | "\(.Name)=\(.Value)"' \
-  | sed -e "s#^/$INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT/##" \
-  | sort
+  | jq -r '.Parameters |sort_by(.Name) | .[] | "\(.Name)=\(.Value)"' \
+  | sed -e "s#^/$INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT/##"


### PR DESCRIPTION
If we have multiline variables then sorting the output with the sort command puts things in the wrong place.

```
 $  dalmatian service list-environment-variables -i dxw-govpress -e staging -s saluki-test
==> Assuming role to provide access to dxw-govpress infrastructure account ...
==> Retrieving env vars for dxw-govpress/saluki-test/staging from Parameter Store...
MULTILINE_BASH=foo:$1$[REDACTED]/i.
MULTILINE_ZSH=foo:$1$[REDACTED]/i.
OTHER_THING=blah
bar:$apr1$[REDACTED]/
bar:$apr1$[REDACTED]/
```

If we use `jq` to sort before outputting multiline variables look better

```
 $  dalmatian service list-environment-variables -i dxw-govpress -e staging -s sa
luki-test
==> Assume role credentials expired ...
==> Requesting Assume Role credentials ...
==> Assuming role to provide access to dxw-govpress infrastructure account ...
==> Retrieving env vars for dxw-govpress/saluki-test/staging from Parameter Store...
MULTILINE_BASH=foo:$1$[REDACTED/i.
bar:$apr1$[REDACTED/
MULTILINE_ZSH=foo:$1$[REDACTED/i.
bar:$apr1$[REDACTED/
OTHER_THING=blah
```