### PR TITLE
Command to retrive a single environment variable

### DIFF
--- a/bin/service/get-environment-variable
+++ b/bin/service/get-environment-variable
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "This command can set environment variables for a service"
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -s <service>           - service name "
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  echo "  -k <key>               - key e.g SMTP_HOST"
+  exit 1
+}
+
+if [ $# -lt 1 ]
+then
+  usage
+fi
+
+while getopts "i:e:s:k:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    s)
+      SERVICE_NAME=$OPTARG
+      ;;
+    k)
+      KEY=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$SERVICE_NAME"
+  || -z "$ENVIRONMENT"
+  || -z "$KEY"
+]]
+then
+  usage
+fi
+  
+echo "==> getting environment variable $KEY for $INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT"
+
+aws ssm get-parameter --with-decryption \
+  --name "/$INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT/$KEY" \
+ | jq -r '.Parameter.Value'


### PR DESCRIPTION
This is particularly useful for multiline variables that can get broken in the list-environment-variables output

```
% dalmatian service get-environment-variable -e staging -i dxw-govpress -s example -k BASIC_AUTH_HTPASSWD
==> Assuming role to provide access to dxw-govpress infrastructure account ...
==> getting environment variable BASIC_AUTH_HTPASSWD for dxw-govpress/example/staging
user1:$apr1$Gdq4r3Yb$lOtYoqBWMnJnfzwFtqzfu.
user2:$apr1$UAzD00fp$C8deX/nCkruePbUbaMTnz.
```