### PR TITLE
Add a command to output AWS CLI env vars for an infrastructure

### DIFF
--- a/bin/util/env
+++ b/bin/util/env
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+usage() {
+  echo 'Get AWS credentials for an infrastructure'
+  echo "Usage: $(basename "$0") [OPTIONS] <command>" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name OPTIONAL defaults to main dalmatian account"
+  echo "  -r                     -  output without export prepended OPTIONAL"
+  
+  exit 1
+}
+
+while getopts "irh" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    r)
+      RAW=true
+      ;;
+    h)
+      usage
+      exit;;
+    *)
+      usage
+      exit;;
+  esac
+done
+
+>&2 echo "==> Getting AWS credentials for $INFRASTRUCTURE_NAME"
+if [ "$RAW" = "true" ]
+then
+env | grep AWS
+else
+env | grep AWS | sed s/^/export\ /g
+fi


### PR DESCRIPTION
When doing things with the AWS cli it is often helpful to use the env vars for
an infrastructure. For instance when doing an s3 sync between accounts.

This is achievable using `dalmatian util exec` but I do it often enough I
decided to make it its own command.