### PR TITLE
Remove printMode

### DIFF
--- a/bin/config/list-infrastructures
+++ b/bin/config/list-infrastructures
@@ -17,4 +17,4 @@ while getopts "h" opt; do
       exit;;
   esac
 done
-yq r --printMode p "$APP_ROOT/bin/tmp/dalmatian-config/dalmatian.yml" infrastructures.* | sed 's/infrastructures.//g'
+yq e '.infrastructures | keys()' "$APP_ROOT/bin/tmp/dalmatian-config/dalmatian.yml" | sed 's/- *//g'


### PR DESCRIPTION
yq 4 does not support printMode

Not 100% sure whether this does the correct behaviour, but it feels pretty right.

```
>  dalmatian config list-infrastructures
bbb
caselawstg
caselaw
dalmatian1
dashboards
dfefh
dfelp
dfeskills
dxwgovpress
judiciary
mettvh
mindsbs
nao
nhsxwebsite
nsirainbow
ons
rwm
testapp
tvh
```