### PR TITLE
Make shell completion script compatible with Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,29 @@ Console and setting it up afresh.
 
   `dalmatian -l`
 
-### Bash completion
+### Shell completion
+**Bash (/bin/bash)**
 
 Add the full path to the `support/bash-completion.sh` script to your `~/.bashrc` file
 
 eg:
 
 ```
-# .bashrc
+# ~/.bashrc
+
 source /path/to/dalmatian-tools/support/bash-completion.sh
+```
+
+**Zsh (/bin/zsh)**
+
+Add the full path to the `support/zsh-completion.sh` script to your `~/.zshrc` file
+
+eg:
+
+```
+# ~/.zshrc
+
+autoload -Uz +X compinit && compinit
+autoload -Uz +X bashcompinit && bashcompinit
+source /path/to/dalmatian-tools/support/zsh-completion.sh
 ```

--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -10,7 +10,7 @@ usage() {
   echo "  SUBCOMMAND COMMAND -h  - show command help"
   echo "    Or:"
   echo "  -h                     - help"
-  echo "  -l                     - list comands"
+  echo "  -l                     - list commands"
   exit 1
 }
 

--- a/support/bash-completion.sh
+++ b/support/bash-completion.sh
@@ -14,7 +14,7 @@ _dalmatian_completion() {
     while IFS=  read -r -d $'\0'; do
       DIRS+=("$REPLY")
     done < <(find "$DALMATIAN_BIN_PATH" -maxdepth 1 -type d -print0)
-    
+
     FILES=()
     while IFS=  read -r -d $'\0'; do
       FILES+=("$REPLY")

--- a/support/zsh-completion.sh
+++ b/support/zsh-completion.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+_dalmatian_completions_filter() {
+  local words="$1"
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  local result=()
+
+  if [[ "${cur:0:1}" == "-" ]]; then
+    echo "$words"
+
+  else
+    for word in $words; do
+      [[ "${word:0:1}" != "-" ]] && result+=("$word")
+    done
+
+    echo "${result[*]}"
+
+  fi
+}
+
+_dalmatian_completions() {
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  local compwords=("${COMP_WORDS[@]:1:$COMP_CWORD-1}")
+  local compline="${compwords[*]}"
+  local dir
+  local bindir
+  dir=$(command -v "dalmatian")
+  bindir=$(dirname "$dir")
+
+  case "$compline" in
+    'certificate'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_dalmatian_completions_filter "$(find "$bindir/certificate" -type f -mindepth 1 -maxdepth 1 -exec basename {} \;)")" -- "$cur" )
+      ;;
+
+    'cloudfront'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_dalmatian_completions_filter "$(find "$bindir/cloudfront" -type f -mindepth 1 -maxdepth 1 -exec basename {} \;)")" -- "$cur" )
+      ;;
+
+    'service'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_dalmatian_completions_filter "$(find "$bindir/service" -type f -mindepth 1 -maxdepth 1 -exec basename {} \;)")" -- "$cur" )
+      ;;
+
+    'config')
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_dalmatian_completions_filter "$(find "$bindir/config" -type f -mindepth 1 -maxdepth 1 -exec basename {} \;)")" -- "$cur" )
+      ;;
+
+    'util'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_dalmatian_completions_filter "$(find "$bindir/util" -type f -mindepth 1 -maxdepth 1 -exec basename {} \;)")" -- "$cur" )
+      ;;
+
+    'rds'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_dalmatian_completions_filter "$(find "$bindir/rds" -type f -mindepth 1 -maxdepth 1 -exec basename {} \;)")" -- "$cur" )
+      ;;
+
+    'ecs'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_dalmatian_completions_filter "$(find "$bindir/ecs" -type f -mindepth 1 -maxdepth 1 -exec basename {} \;)")" -- "$cur" )
+      ;;
+
+    'waf'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_dalmatian_completions_filter "$(find "$bindir/waf" -type f -mindepth 1 -maxdepth 1 -exec basename {} \;)")" -- "$cur" )
+      ;;
+
+    'aws'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_dalmatian_completions_filter "$(find "$bindir/aws" -type f -mindepth 1 -maxdepth 1 -exec basename {} \;)")" -- "$cur" )
+      ;;
+
+    'ci'*)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_dalmatian_completions_filter "$(find "$bindir/ci" -type f -mindepth 1 -maxdepth 1 -exec basename {} \;)")" -- "$cur" )
+      ;;
+
+    *)
+      while read -r; do COMPREPLY+=( "$REPLY" ); done < <( compgen -W "$(_dalmatian_completions_filter "-h -l $(find "$bindir" -type d -not -path "$bindir"/configure-commands -mindepth 1 -maxdepth 1 -exec basename {} \;)")" -- "$cur" )
+      ;;
+
+  esac
+} &&
+complete -F _dalmatian_completions dalmatian
+
+# ex: filetype=sh

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 find ./bin -path ./bin/tmp -prune -o -type f -exec shellcheck -x {} +
+find ./support -type f -exec shellcheck -x {} +


### PR DESCRIPTION
**Problem:**
The current version of the `bash-completion.sh` file is not directly compatible with the `zsh` shell as it was written for `bash` which means only people using `bash` get access to tab completions.

**Solution:**
I've written a new `zsh-completion.sh` file to improve compatibilty when inherited into a `zsh` shell using `bashcompinit`.

This change will mean engineers who use the out-of-the-box shell (zsh) on macOS can also take full advantage of the tab-completions.

It's not perfect, there are a few quirks with it so there's certainly room for improvement. As a result I have left in the existing `bash-completion.sh` 

**Misc changes**
- Added note in the readme which includes what steps are required to enable tab completions in zsh
- Minor spelling correction in the dalmatian binary (comands to commands)

**Trello card**
https://trello.com/c/j1Q6KiJk/300-update-dalmatian-tools-tab-completion-to-support-engineers-using-zsh