### PR TITLE
Switch to master ref for shellcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ludeeus/action-shellcheck@1.1.0
+      - uses: ludeeus/action-shellcheck@master
         env:
           SHELLCHECK_OPTS: -x


### PR DESCRIPTION
- Brings the github action up-to-date and resolves deprecation notices

The shellcheck action has had [a lot of commits to `master`](https://github.com/ludeeus/action-shellcheck/compare/1.1.0...master) since 2021 which resolves a lot of issues regarding deprecation notices.