### PR TITLE
Override the default location of dalmatian.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,10 @@ autoload -Uz +X compinit && compinit
 autoload -Uz +X bashcompinit && bashcompinit
 source /path/to/dalmatian-tools/support/zsh-completion.sh
 ```
+
+### Environment Variables
+
+- DALMATIAN_CONFIG_PATH
+  Set a path to dalmatian.yml to override the use of the checkout used by the
+  tools by default. Useful if bringing up a service or infrastructure whose
+  config hasn't been merged in yet.

--- a/bin/aws/assume-infrastructure-role
+++ b/bin/aws/assume-infrastructure-role
@@ -35,12 +35,19 @@ if [ -z "$INFRASTRUCTURE_NAME" ]; then
   usage
 fi
 
+if [ -z "$DALMATIAN_CONFIG_PATH" ]
+then
 "$APP_ROOT/bin/dalmatian-refresh-config" > /dev/null
 
 echo "==> Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure account ..."
 
 INFRASTRUCTURE_ACCOUNT_ID=$(yq e ".infrastructures.$INFRASTRUCTURE_NAME.account_id" "$APP_ROOT/bin/tmp/dalmatian-config/dalmatian.yml")
+else
+  echo "==> Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure account ..."
 
+INFRASTRUCTURE_ACCOUNT_ID=$(yq e ".infrastructures.$INFRASTRUCTURE_NAME.account_id" "$DALMATIAN_CONFIG_PATH")
+
+fi
 if [ -z "$INFRASTRUCTURE_ACCOUNT_ID" ]
 then
   echo "==> Error: Infrastructure '$INFRASTRUCTURE_NAME' not found in dalmatian-config,"


### PR DESCRIPTION
If working on a new infrastructures for dalmatian the default behaviour of
dalmatian tools means that it wont pick up your unmerged config changes. Use an
environment variable to override this. Has the added benefit that we arent
constantly doing git clones of the config repo.