### PR TITLE
Make dalmatian login deal with errors better

### DIFF
--- a/bin/configure-commands/login
+++ b/bin/configure-commands/login
@@ -116,4 +116,5 @@ echo "$CREDENTIALS_JSON_STRING" | gpg \
 chmod 600 "$DALMATIAN_CREDENTIALS_FILE"
 else
   echo "==> Login failed"
+  exit 1
 fi


### PR DESCRIPTION
Help users to enter thier MFA secret correctly and only write out a config if everything works.