### PR TITLE
Apply linear back-off to AWS API in certificate create

### DIFF
--- a/bin/certificate/create
+++ b/bin/certificate/create
@@ -62,11 +62,26 @@ fi
 EUW2_ARN=$(aws acm request-certificate --domain-name "$DOMAIN" --subject-alternative-names $SAN --validation-method DNS --region eu-west-2 | jq -r '.CertificateArn')
 #shellcheck disable=SC2086 
 USE1_ARN=$(aws acm request-certificate --domain-name "$DOMAIN" --subject-alternative-names $SAN --validation-method DNS --region us-east-1 | jq -r '.CertificateArn')
-# Sleep to allow the AWS API to become consistent
-sleep 2
-DNS=$(aws acm describe-certificate --certificate-arn "$EUW2_ARN" | jq -r '.Certificate.DomainValidationOptions[] | "\(.ResourceRecord.Name) CNAME \(.ResourceRecord.Value)"')
 
-echo "Load balancer SSL cert is $EUW2_ARN"
-echo "CloudFront SSL cert is $USE1_ARN"
-echo "DNS validation entries are:"
-echo "$DNS"
+# Apply a linear back-off before reporting back to the user. Allow the user
+# to see some output if the API never becomes consistent and they have to kill
+# the script with Ctrl+c.
+DNS="null"
+trap print_cert INT
+
+function print_cert() {
+  echo "Load balancer SSL cert is $EUW2_ARN"
+  echo "CloudFront SSL cert is $USE1_ARN"
+  echo "DNS validation entries are:"
+  echo "$DNS"
+  exit 0
+}
+
+while echo "$DNS" | grep -q "null"
+do
+  echo "Waiting for AWS API to become consistent. This may take more than one attempt..."
+  sleep 2
+  DNS=$(aws acm describe-certificate --certificate-arn "$EUW2_ARN" | jq -r '.Certificate.DomainValidationOptions[] | "\(.ResourceRecord.Name) CNAME \(.ResourceRecord.Value)"')
+done
+
+print_cert


### PR DESCRIPTION
Previously, when we create an SSL cert, we waited a fixed number of seconds (2) for the AWS API to become consistent. In practice, we sometimes need to wait longer.

This commit replaces the fixed sleep with a linear back-off. We assume that the API will become consistent at some point, and so we don't attempt to break the loop if it does not. However, If the user gives up and kills the script, we still attempt to print some useful output.

I'm not sure how best to test this BTW!