### PR TITLE
Add a script to tell user how old their key is

### DIFF
--- a/bin/aws/key-age
+++ b/bin/aws/key-age
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Check the age of your AWS access key"
+  exit 1
+}
+
+while getopts "i:h" opt; do
+  case $opt in
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+read -r -p "Enter your AWS username: " username
+
+# Get access key metadata for the user
+metadata=$(aws iam list-access-keys --user-name "$username")
+
+# Check if any access keys were found
+if [[ $(echo "$metadata" | jq '.AccessKeyMetadata | length') == 0 ]]
+then
+    echo "No access keys found for user $username"
+    exit 1
+fi
+
+# Loop through the access keys and calculate their age
+now=$(gdate +%s)
+for key in $(echo "$metadata" | jq -r '.AccessKeyMetadata[] | @base64'); do
+    key_id=$(echo "$key" | base64 --decode | jq -r '.AccessKeyId')
+    create_date=$(echo "$key" | base64 --decode | jq -r '.CreateDate')
+    create_date=$(gdate -d "$create_date" +%s)
+    age=$(( (now - create_date) / 86400 ))
+
+# Print access key information and age
+    echo "Access key ID: $key_id"
+    echo "Created on: $(gdate -d @"$create_date" +%Y-%m-%d)"
+    echo "Age in days: $age"
+
+# Check if access key is more than 180 days old and prompt user to rotate if it is
+    if [[ $age -gt 180 ]]
+    then
+        echo "WARNING: Access key is more than 180 days old and should be rotated."
+    fi
+done

--- a/bin/configure-commands/login
+++ b/bin/configure-commands/login
@@ -11,7 +11,6 @@ then
   exit 1
 fi
 
-
 if ! "$APP_ROOT/bin/aws/awscli-version"
 then
   exit 1
@@ -65,6 +64,12 @@ echo "  User ID: $USER_ID"
 echo "  Account: $ACCOUNT_ID"
 echo "  Arn:     $USER_ARN"
 
+echo "==> Checking access key age"
+if ! "$APP_ROOT/bin/aws/key-age"
+then
+  exit 1
+fi
+
 echo "==> Saving configuration settings in $DALMATIAN_CONFIG_FILE ..."
 
 CONFIG_JSON_STRING=$(
@@ -80,7 +85,6 @@ CONFIG_JSON_STRING=$(
 )
 
 echo "$CONFIG_JSON_STRING" > "$DALMATIAN_CONFIG_FILE"
-
 
 echo "==> Attempting MFA..."
 


### PR DESCRIPTION
This script currently requires a user to input their aws username. However, there might be a better way of doing this as it will be added to the dalmatian login script.

https://github.com/dxw/dalmatian-tools/issues/33