### PR TITLE
Avoid file-not-found error from realpath

### DIFF
--- a/bin/rds/export-dump
+++ b/bin/rds/export-dump
@@ -63,6 +63,9 @@ fi
 
 if [ -n "$OUTPUT_FILE_PATH" ]
 then
+  if [[ ! -f "$OUTPUT_FILE_PATH" ]]; then
+    touch "$OUTPUT_FILE_PATH"
+  fi
   OUTPUT_FILE_PATH="$(realpath "$OUTPUT_FILE_PATH")"
 else
   OUTPUT_FILE_PATH="."


### PR DESCRIPTION
Previously: if `dalmatian rds export-dump ...` was run with an argument `-o <filename>` the script failed with a file not found error if `<filename>` did not exist, because `realpath` cannot create a canonical path from a filename if the file does not exist.

After: if the output file does not exist, we run `touch` on that path before calling `realpath`. From the perspective of a user, dalmatian will create the dump file, if it does not yet exist.