### PR TITLE
Add a script to delete unused SSL certificates

### DIFF
--- a/bin/certificate/delete
+++ b/bin/certificate/delete
@@ -11,7 +11,7 @@ usage() {
   echo "  -h                         - help"
   echo "  -i <infrastructure>        - infrastructure name"
   echo "  -c <certificate arn>       - remove a single certificate with a given ARN"
-  echo "  -D <domain>                - remove all certificates for domain which are not ISSUED"
+  echo "  -D <domain>                - remove all certificates for domain which are not ISSUED or PENDING"
   echo "  -d                         - perform a dry run, do not delete any certificates"
   exit 1
 }
@@ -106,8 +106,9 @@ for cert_arn in "${ALL_CERTIFICATES[@]}"
 do
   CERT_REGION=$(get_region "${cert_arn}")
   CERTIFICATE=$(aws acm describe-certificate --certificate-arn "$cert_arn" --region "$CERT_REGION")
+  STATUS=$(echo "$CERTIFICATE" | jq -r '.Certificate | .Status')
 
-  if [ "$(echo "$CERTIFICATE" | jq -r '.Certificate | .Status')" != "ISSUED" ];
+  if [ "$STATUS" != "ISSUED" ] && [ "$STATUS" != "PENDING" ];
   then
     delete_cert "$(echo "$CERTIFICATE" | jq -r '.Certificate | .CertificateArn')"
   fi


### PR DESCRIPTION
Fixes #95 

`dalmatian certificate delete` will either delete a certificate with a given ARN (`-c`) or all un-issued certificates for a given domain (`-D`).

This is mainly intended to be used in situations where certs have been created, but could not be vefified, for example due to missing DNS records.

The `-d` switch can be used to perform a dry-run, if the user is unsure about what operations the script will perform.

Usage:

    ❯ dalmatian certificate delete -h
    Delete an unused CloudFront certifcate
    e.g.    dalmatian certificate delete -i infra -D example.com
            dalmatian certificate delete -i infra -c arn:aws:acm:region:account:certificate/12345678-1234-1234-1234-123456789012
    Usage: delete [OPTIONS]
      -h                         - help
      -i <infrastructure>        - infrastructure name
      -c <certificate arn>       - remove a single certificate with a given ARN
      -D <domain>                - remove all certificates for domain which are not ISSUED
      -d                         - perform a dry run, do not delete any certificates



### Testing - delete a single cert

```bash
❯ dalmatian certificate list -i dxw-govpress -d love.lambeth.gov.uk -D
==> Assuming role to provide access to dxw-govpress infrastructure account ...
arn:aws:acm:eu-west-2:666653442229:certificate/d8597dad-0f5c-427e-a957-61278f1a3f0b love.lambeth.gov.uk VALIDATION_TIMED_OUT
Validation records unavailable

arn:aws:acm:eu-west-2:666653442229:certificate/f30a8406-78e7-449f-bb61-a50496083db3 love.lambeth.gov.uk VALIDATION_TIMED_OUT
Validation records unavailable

arn:aws:acm:eu-west-2:666653442229:certificate/3005d03f-6fc1-4f22-9d7a-3764b82dfff8 love.lambeth.gov.uk ISSUED
_844f534d17142ad0a8479dabdfb2bcaa.love.lambeth.gov.uk. CNAME _b8e300154b1b60a0213ef3e200a0d645.dnzkjbsjxj.acm-validations.aws.

arn:aws:acm:us-east-1:666653442229:certificate/fe583fe4-81eb-47ca-ae81-72532ce60ca4 love.lambeth.gov.uk VALIDATION_TIMED_OUT
Validation records unavailable

arn:aws:acm:us-east-1:666653442229:certificate/0813cc07-982b-4a84-ba0c-5e988e17e3b1 love.lambeth.gov.uk VALIDATION_TIMED_OUT
Validation records unavailable

arn:aws:acm:us-east-1:666653442229:certificate/f19b919d-e2d2-4e52-bd5b-97fb905e8b76 love.lambeth.gov.uk ISSUED
_844f534d17142ad0a8479dabdfb2bcaa.love.lambeth.gov.uk. CNAME _b8e300154b1b60a0213ef3e200a0d645.dnzkjbsjxj.acm-validations.aws.
```


```bash
❯ dalmatian certificate delete -i dxw-govpress -c arn:aws:acm:eu-west-2:666653442229:certificate/d8597dad-0f5c-427e-a957-61278f1a3f0b
==> Assuming role to provide access to dxw-govpress infrastructure account ...
Deleted: arn:aws:acm:eu-west-2:666653442229:certificate/d8597dad-0f5c-427e-a957-61278f1a3f0b
```


```bash
❯ dalmatian certificate list -i dxw-govpress -d love.lambeth.gov.uk -D
==> Assuming role to provide access to dxw-govpress infrastructure account ...
arn:aws:acm:eu-west-2:666653442229:certificate/f30a8406-78e7-449f-bb61-a50496083db3 love.lambeth.gov.uk VALIDATION_TIMED_OUT
Validation records unavailable

arn:aws:acm:eu-west-2:666653442229:certificate/3005d03f-6fc1-4f22-9d7a-3764b82dfff8 love.lambeth.gov.uk ISSUED
_844f534d17142ad0a8479dabdfb2bcaa.love.lambeth.gov.uk. CNAME _b8e300154b1b60a0213ef3e200a0d645.dnzkjbsjxj.acm-validations.aws.

arn:aws:acm:us-east-1:666653442229:certificate/fe583fe4-81eb-47ca-ae81-72532ce60ca4 love.lambeth.gov.uk VALIDATION_TIMED_OUT
Validation records unavailable

arn:aws:acm:us-east-1:666653442229:certificate/0813cc07-982b-4a84-ba0c-5e988e17e3b1 love.lambeth.gov.uk VALIDATION_TIMED_OUT
Validation records unavailable

arn:aws:acm:us-east-1:666653442229:certificate/f19b919d-e2d2-4e52-bd5b-97fb905e8b76 love.lambeth.gov.uk ISSUED
_844f534d17142ad0a8479dabdfb2bcaa.love.lambeth.gov.uk. CNAME _b8e300154b1b60a0213ef3e200a0d645.dnzkjbsjxj.acm-validations.aws.
```

### Testing - delete all non-issued certs for domain

```bash
❯ dalmatian certificate list -i dxw-govpress -d love.lambeth.gov.uk -D
==> Assuming role to provide access to dxw-govpress infrastructure account ...
arn:aws:acm:eu-west-2:666653442229:certificate/3005d03f-6fc1-4f22-9d7a-3764b82dfff8 love.lambeth.gov.uk ISSUED
_844f534d17142ad0a8479dabdfb2bcaa.love.lambeth.gov.uk. CNAME _b8e300154b1b60a0213ef3e200a0d645.dnzkjbsjxj.acm-validations.aws.

arn:aws:acm:us-east-1:666653442229:certificate/fe583fe4-81eb-47ca-ae81-72532ce60ca4 love.lambeth.gov.uk VALIDATION_TIMED_OUT
Validation records unavailable

arn:aws:acm:us-east-1:666653442229:certificate/0813cc07-982b-4a84-ba0c-5e988e17e3b1 love.lambeth.gov.uk VALIDATION_TIMED_OUT
Validation records unavailable

arn:aws:acm:us-east-1:666653442229:certificate/f19b919d-e2d2-4e52-bd5b-97fb905e8b76 love.lambeth.gov.uk ISSUED
_844f534d17142ad0a8479dabdfb2bcaa.love.lambeth.gov.uk. CNAME _b8e300154b1b60a0213ef3e200a0d645.dnzkjbsjxj.acm-validations.aws.
```


```bash
❯ dalmatian certificate delete -i dxw-govpress -D love.lambeth.gov.uk
==> Assuming role to provide access to dxw-govpress infrastructure account ...
Deleted: arn:aws:acm:us-east-1:666653442229:certificate/fe583fe4-81eb-47ca-ae81-72532ce60ca4
Deleted: arn:aws:acm:us-east-1:666653442229:certificate/0813cc07-982b-4a84-ba0c-5e988e17e3b1
```


```bash
❯ dalmatian certificate list -i dxw-govpress -d love.lambeth.gov.uk -D
==> Assuming role to provide access to dxw-govpress infrastructure account ...
arn:aws:acm:eu-west-2:666653442229:certificate/3005d03f-6fc1-4f22-9d7a-3764b82dfff8 love.lambeth.gov.uk ISSUED
_844f534d17142ad0a8479dabdfb2bcaa.love.lambeth.gov.uk. CNAME _b8e300154b1b60a0213ef3e200a0d645.dnzkjbsjxj.acm-validations.aws.

arn:aws:acm:us-east-1:666653442229:certificate/f19b919d-e2d2-4e52-bd5b-97fb905e8b76 love.lambeth.gov.uk ISSUED
_844f534d17142ad0a8479dabdfb2bcaa.love.lambeth.gov.uk. CNAME _b8e300154b1b60a0213ef3e200a0d645.dnzkjbsjxj.acm-validations.aws.
```