### PR TITLE
Add commands to manage aurora databases

### DIFF
--- a/bin/aurora/count-sql-backups
+++ b/bin/aurora/count-sql-backups
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -r <aurora_name>          - RDS name (as defined in the Dalmatian config)"
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  echo "  -d <date>              - date (optional e.g %Y-%m-%d)"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ]
+then
+ usage
+fi
+
+while getopts "i:r:e:d:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    r)
+      RDS_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    d)
+      DATE=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$RDS_NAME"
+  || -z "$ENVIRONMENT"
+]]
+then
+  usage
+fi
+
+# Remove dashes from the variables to create the RDS identifier, because dashes
+# aren't allowed in RDS identifiers. Dalmatian removes them on deployment, so we
+# need to remove them here to get the correct identifier.
+RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
+
+S3_BUCKET_NAME="$INFRASTRUCTURE_NAME-$RDS_IDENTIFIER-sql-backup"
+TODAY=$(date +%Y-%m-%d)
+
+echo "==> Counting SQL backups in $INFRASTRUCTURE_NAME $RDS_NAME $ENVIRONMENT..."
+
+if [ -n "$DATE" ]
+then
+ aws s3api list-objects-v2 \
+   --bucket "$S3_BUCKET_NAME" \
+   --query "Contents[?contains(LastModified,\`${DATE}\`)].Key" | jq -r 'length'
+else
+ aws s3api list-objects-v2 \
+   --bucket "$S3_BUCKET_NAME" \
+   --query "Contents[?contains(LastModified,\`${TODAY}\`)].Key" | jq -r 'length'
+fi

--- a/bin/aurora/create-database
+++ b/bin/aurora/create-database
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -r <aurora_name>          - RDS name (as defined in the Dalmatian config)"
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  echo "  -d <db_name>           - name of database to create"
+  echo "  -u <user_name>         - name of user to create"
+  echo "  -P <user_password>     - password for user to be created"
+  echo "  -I <ecs_instance_id>   - ECS instance ID to connect through (optional)"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ]
+then
+ usage
+fi
+
+while getopts "i:e:r:d:u:P:I:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    r)
+      RDS_NAME=$OPTARG
+      ;;
+    d)
+      DB_NAME=$OPTARG
+      ;;
+    u)
+      USER_NAME=$OPTARG
+      ;;
+    P)
+      USER_PASSWORD=$OPTARG
+      ;;
+    I)
+      ECS_INSTANCE_ID=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$RDS_NAME"
+  || -z "$DB_NAME"
+  || -z "$USER_NAME"
+  || -z "$USER_PASSWORD"
+  || -z "$ENVIRONMENT"
+]]
+then
+  usage
+fi
+
+# Remove dashes from the variables to create the RDS identifier, because dashes
+# aren't allowed in RDS identifiers. Dalmatian removes them on deployment, so we
+# need to remove them here to get the correct identifier.
+RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
+
+echo "==> Retrieving RDS root password from Parameter Store..."
+
+RDS_ROOT_PASSWORD_PARAMETER=$(
+  aws ssm get-parameters \
+    --names "/$INFRASTRUCTURE_NAME/$RDS_IDENTIFIER-aurora/password" \
+    --with-decryption
+)
+RDS_ROOT_PASSWORD=$(
+  echo "$RDS_ROOT_PASSWORD_PARAMETER" \
+    | jq -r .Parameters[0].Value
+)
+
+echo "==> Getting RDS info..."
+
+RDS_INFO=$(
+  aws rds describe-db-clusters \
+    --db-cluster-identifier "$RDS_IDENTIFIER"
+)
+RDS_ENGINE=$(echo "$RDS_INFO" | jq -r .DBClusters[0].Engine)
+RDS_ROOT_USERNAME=$(echo "$RDS_INFO" | jq -r .DBClusters[0].MasterUsername)
+
+echo "Engine: $RDS_ENGINE"
+echo "Root username: $RDS_ROOT_USERNAME"
+
+if [ -z "$ECS_INSTANCE_ID" ]
+then
+  echo "==> Finding ECS instance..."
+
+  ECS_INSTANCES=$(
+    aws ec2 describe-instances \
+      --filters "Name=instance-state-code,Values=16" Name=tag:Name,Values="$INFRASTRUCTURE_NAME-$ENVIRONMENT*"
+  )
+  ECS_INSTANCE_ID=$(
+    echo "$ECS_INSTANCES" \
+      | jq -r .Reservations[0].Instances[0].InstanceId
+  )
+fi
+
+echo "ECS instance ID: $ECS_INSTANCE_ID"
+
+echo "==> Creating database..."
+
+aws ssm start-session \
+  --target "$ECS_INSTANCE_ID" \
+  --document-name "$RDS_IDENTIFIER-aurora-db-creation" \
+  --parameters "RootPassword=$RDS_ROOT_PASSWORD,NewDbName=$DB_NAME,NewUserName=$USER_NAME,NewUserPassword=$USER_PASSWORD"
+
+echo "Success!"

--- a/bin/aurora/export-dump
+++ b/bin/aurora/export-dump
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -r <aurora_name>          - RDS name (as defined in the Dalmatian config)"
+  echo "  -d <database_name>     - database name"
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  echo "  -o <output_file_path>  - output file path"
+  echo "  -I <ecs_instance_id>   - ECS insatnce ID to connect through (optional)"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ]
+then
+ usage
+fi
+
+while getopts "i:e:r:d:o:I:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    r)
+      RDS_NAME=$OPTARG
+      ;;
+    d)
+      DATABASE_NAME=$OPTARG
+      ;;
+    o)
+      OUTPUT_FILE_PATH=$OPTARG
+      ;;
+    I)
+      ECS_INSTANCE_ID=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$RDS_NAME"
+  || -z "$DATABASE_NAME"
+  || -z "$ENVIRONMENT"
+]]
+then
+  usage
+fi
+
+if [ -n "$OUTPUT_FILE_PATH" ]
+then
+  OUTPUT_FILE_PATH="$(realpath "$OUTPUT_FILE_PATH")"
+else
+  OUTPUT_FILE_PATH="."
+fi
+
+# Remove dashes from the variables to create the RDS identifier, because dashes
+# aren't allowed in RDS identifiers. Dalmatian removes them on deployment, so we
+# need to remove them here to get the correct identifier.
+RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
+
+echo "==> Retrieving RDS root password from Parameter Store..."
+
+RDS_ROOT_PASSWORD_PARAMETER=$(
+  aws ssm get-parameters \
+    --names "/$INFRASTRUCTURE_NAME/$RDS_IDENTIFIER-aurora/password" \
+    --with-decryption
+)
+RDS_ROOT_PASSWORD=$(
+  echo "$RDS_ROOT_PASSWORD_PARAMETER" \
+    | jq -r .Parameters[0].Value
+)
+
+echo "==> Getting RDS info..."
+
+RDS_INFO=$(
+  aws rds describe-db-clusters \
+    --db-cluster-identifier "$RDS_IDENTIFIER"
+)
+RDS_ENGINE=$(echo "$RDS_INFO" | jq -r .DBClusters[0].Engine)
+RDS_ROOT_USERNAME=$(echo "$RDS_INFO" | jq -r .DBClusters[0].MasterUsername)
+
+echo "Engine: $RDS_ENGINE"
+echo "Root username: $RDS_ROOT_USERNAME"
+
+if [ -z "$ECS_INSTANCE_ID" ]
+then
+  echo "==> Finding ECS instance..."
+
+  ECS_INSTANCES=$(
+    aws ec2 describe-instances \
+      --filters "Name=instance-state-code,Values=16" Name=tag:Name,Values="$INFRASTRUCTURE_NAME-$ENVIRONMENT*"
+  )
+  ECS_INSTANCE_ID=$(
+    echo "$ECS_INSTANCES" \
+      | jq -r .Reservations[0].Instances[0].InstanceId
+  )
+fi
+
+echo "ECS instance ID: $ECS_INSTANCE_ID"
+
+echo "Exporting $DATABASE_NAME db from $RDS_IDENTIFIER aurora..."
+
+aws ssm start-session \
+  --target "$ECS_INSTANCE_ID" \
+  --document-name "$RDS_IDENTIFIER-aurora-sql-dump" \
+  --parameters "RootPassword=$RDS_ROOT_PASSWORD,DatabaseName=$DATABASE_NAME"
+
+echo "==> Export complete"
+
+SQL_FILE_NAME="$DATABASE_NAME-$ENVIRONMENT-sql-export.sql"
+S3_BUCKET_NAME="$INFRASTRUCTURE_NAME-ecs-$ENVIRONMENT-dalmatian-transfer"
+
+echo "==> Starting download of $SQL_FILE_NAME from s3 bucket $S3_BUCKET_NAME..."
+
+aws s3 cp "s3://$S3_BUCKET_NAME/db_exports/$SQL_FILE_NAME" "$OUTPUT_FILE_PATH"
+
+echo "==> Deleting sql file from S3 ..."
+
+aws s3 rm "s3://$S3_BUCKET_NAME/db_exports/$SQL_FILE_NAME"

--- a/bin/aurora/get-root-password
+++ b/bin/aurora/get-root-password
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: dalmatian $(basename "$(dirname "${BASH_SOURCE[0]}")") $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -r <aurora_name>          - RDS name (as defined in the Dalmatian config)"
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ];
+then
+ usage
+fi
+
+while getopts "i:e:r:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    r)
+      RDS_NAME=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$RDS_NAME"
+  || -z "$ENVIRONMENT"
+]]; then
+  usage
+fi
+
+# Remove dashes from the variables to create the RDS identifier, because dashes
+# aren't allowed in RDS identifiers. Dalmatian removes them on deployment, so we
+# need to remove them here to get the correct identifier.
+RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
+
+echo "==> Retrieving RDS root password from Parameter Store..."
+
+RDS_ROOT_PASSWORD_PARAMETER=$(
+  aws ssm get-parameters \
+    --names "/$INFRASTRUCTURE_NAME/$RDS_IDENTIFIER-aurora/password" \
+    --with-decryption
+)
+RDS_ROOT_PASSWORD=$(
+  echo "$RDS_ROOT_PASSWORD_PARAMETER" \
+    | jq -r .Parameters[0].Value
+)
+
+echo "==> Getting RDS info..."
+
+RDS_INFO=$(
+  aws rds describe-db-clusters \
+    --db-cluster-identifier "$RDS_IDENTIFIER"
+)
+RDS_ROOT_USERNAME=$(echo "$RDS_INFO" | jq -r .DBClusters[0].MasterUsername)
+
+echo "Root username: $RDS_ROOT_USERNAME"
+echo "Root password: $RDS_ROOT_PASSWORD"

--- a/bin/aurora/import-dump
+++ b/bin/aurora/import-dump
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -r <aurora_name>          - RDS name (as defined in the Dalmatian config)"
+  echo "  -d <database_name>     - database name"
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  echo "  -f <dump_file>         - DB dump file"
+  echo "  -R <rewrite_file>      - Rewrite file"
+  echo "  -I <ecs_instance_id>   - ECS instance ID to connect through (optional)"
+  echo "  -Y <Yes>               - Auto awnser Yes (Should only be used in scripts"
+  echo "                           that ensure humans validate DB overwrites)"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ]
+then
+ usage
+fi
+
+SCRIPT_PATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REWRITE_FILE=""
+
+while getopts "i:e:r:d:f:R:p:I:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    r)
+      RDS_NAME=$OPTARG
+      ;;
+    d)
+      DATABASE_NAME=$OPTARG
+      ;;
+    f)
+      DB_DUMP_FILE=$OPTARG
+      ;;
+    R)
+      REWRITE_FILE=$OPTARG
+      ;;
+    I)
+      ECS_INSTANCE_ID=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$RDS_NAME"
+  || -z "$DATABASE_NAME"
+  || -z "$ENVIRONMENT"
+]]
+then
+  usage
+fi
+
+# Remove dashes from the variables to create the RDS identifier, because dashes
+# aren't allowed in RDS identifiers. Dalmatian removes them on deployment, so we
+# need to remove them here to get the correct identifier.
+RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
+
+echo "==> Retrieving RDS root password from Parameter Store..."
+
+RDS_ROOT_PASSWORD_PARAMETER=$(
+  aws ssm get-parameters \
+    --names "/$INFRASTRUCTURE_NAME/$RDS_IDENTIFIER-aurora/password" \
+    --with-decryption
+)
+RDS_ROOT_PASSWORD=$(
+  echo "$RDS_ROOT_PASSWORD_PARAMETER" \
+    | jq -r .Parameters[0].Value
+)
+
+echo "==> Getting RDS info..."
+
+RDS_INFO=$(
+  aws rds describe-db-clusters \
+    --db-cluster-identifier "$RDS_IDENTIFIER"
+)
+RDS_ENGINE=$(echo "$RDS_INFO" | jq -r .DBClusters[0].Engine)
+RDS_ROOT_USERNAME=$(echo "$RDS_INFO" | jq -r .DBClusters[0].MasterUsername)
+
+echo "Engine: $RDS_ENGINE"
+echo "Root username: $RDS_ROOT_USERNAME"
+
+if [ -z "$ECS_INSTANCE_ID" ]
+then
+  echo "==> Finding ECS instance..."
+
+  ECS_INSTANCES=$(
+    aws ec2 describe-instances \
+      --filters "Name=instance-state-code,Values=16" Name=tag:Name,Values="$INFRASTRUCTURE_NAME-$ENVIRONMENT*"
+  )
+  ECS_INSTANCE_ID=$(
+    echo "$ECS_INSTANCES" \
+      | jq -r .Reservations[0].Instances[0].InstanceId
+  )
+fi
+
+echo "ECS instance ID: $ECS_INSTANCE_ID"
+
+if [ ! -f "$DB_DUMP_FILE" ];
+then
+    echo "$DB_DUMP_FILE not found ..."
+    exit 1
+fi
+
+if [ -n "$REWRITE_FILE" ];
+then
+  INPUT_FILE="$(realpath "$DB_DUMP_FILE")"
+  OUTPUT_PATH="$APP_ROOT/bin/tmp/sql-munged"
+  REWRITE_FILE="$(realpath "$REWRITE_FILE")"
+  cd "$APP_ROOT/lib"
+  "./php-sql-munge.sh" -i "$INPUT_FILE" -o "$OUTPUT_PATH" -r "$REWRITE_FILE"
+  cd "$SCRIPT_PATH"
+  DB_DUMP_FILE="$(basename "$DB_DUMP_FILE")"
+  DB_DUMP_FILE="$OUTPUT_PATH/$DB_DUMP_FILE"
+fi
+
+echo "--------------------------------------------------"
+echo "The RDS:"
+echo "  $RDS_IDENTIFIER"
+echo "in the infrastructure:"
+echo "  $INFRASTRUCTURE_NAME"
+echo "in environment:"
+echo "  $ENVIRONMENT"
+echo "will have the database:"
+echo "  $DATABASE_NAME"
+echo "overwritten with the file:"
+echo "  $DB_DUMP_FILE"
+echo "--------------------------------------------------"
+echo ""
+echo "Are you sure?"
+echo ""
+
+echo "Continue (Yes/No)"
+read -r -p " > " choice
+case "$choice" in
+  Yes ) echo "==> Importing ...";;
+  * ) echo "Aborting!"
+    exit 1
+    ;;
+esac
+
+echo "Uploading $DB_DUMP_FILE ..."
+
+"$APP_ROOT/bin/ecs/file-upload" -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT" -s "$DB_DUMP_FILE" -t "/tmp/$(basename "$DB_DUMP_FILE")" -I "$ECS_INSTANCE_ID"
+
+echo "==> Uploading complete!"
+
+echo "==> Starting import of $RDS_ENGINE $DB_DUMP_FILE file into $RDS_IDENTIFIER..."
+
+aws ssm start-session \
+  --target "$ECS_INSTANCE_ID" \
+  --document-name "$RDS_IDENTIFIER-aurora-sql-import" \
+  --parameters "RootPassword=$RDS_ROOT_PASSWORD,DatabaseName=$DATABASE_NAME,SqlFile=/tmp/$(basename "$DB_DUMP_FILE")"

--- a/bin/aurora/list-databases
+++ b/bin/aurora/list-databases
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -r <aurora_name>          - RDS name (as defined in the Dalmatian config)"
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ]
+then
+ usage
+fi
+
+while getopts "i:e:r:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    r)
+      RDS_NAME=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$ENVIRONMENT"
+  || -z "$RDS_NAME"
+]]
+then
+  usage
+fi
+
+# Remove dashes from the variables to create the RDS identifier, because dashes
+# aren't allowed in RDS identifiers. Dalmatian removes them on deployment, so we
+# need to remove them here to get the correct identifier.
+RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
+
+echo "==> Retrieving RDS root password from Parameter Store..."
+
+RDS_ROOT_PASSWORD_PARAMETER=$(
+  aws ssm get-parameters \
+    --names "/$INFRASTRUCTURE_NAME/$RDS_IDENTIFIER-aurora/password" \
+    --with-decryption
+)
+RDS_ROOT_PASSWORD=$(
+  echo "$RDS_ROOT_PASSWORD_PARAMETER" \
+    | jq -r .Parameters[0].Value
+)
+
+
+if [ -z "$ECS_INSTANCE_ID" ]
+then
+  echo "==> Finding ECS instance..."
+
+  ECS_INSTANCES=$(
+    aws ec2 describe-instances \
+      --filters "Name=instance-state-code,Values=16" Name=tag:Name,Values="$INFRASTRUCTURE_NAME-$ENVIRONMENT*"
+  )
+  ECS_INSTANCE_ID=$(
+    echo "$ECS_INSTANCES" \
+      | jq -r .Reservations[0].Instances[0].InstanceId
+  )
+fi
+
+echo "ECS instance ID: $ECS_INSTANCE_ID"
+
+echo "==> Listing databases..."
+
+aws ssm start-session \
+  --target "$ECS_INSTANCE_ID" \
+  --document-name "$RDS_IDENTIFIER-aurora-db-list" \
+  --parameters "RootPassword=$RDS_ROOT_PASSWORD"
+
+echo "Success!"

--- a/bin/aurora/list-instances
+++ b/bin/aurora/list-instances
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -e <environment>       - environment (eg. 'staging' or 'prod')"
+  echo "  -i <infrastructure>    - infrastructure name"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ]
+then
+ usage
+fi
+
+while getopts "i:e:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME" ||
+  -z "$ENVIRONMENT"
+]]
+then
+  usage
+fi
+
+echo "==> Getting RDS instances in $INFRASTRUCTURE_NAME $ENVIRONMENT..."
+
+RDS_IDENTIFIER_SEARCH="${INFRASTRUCTURE_NAME//-/}.*${ENVIRONMENT//-/}"
+
+aws rds describe-db-clusters  \
+  | jq -r '.DBClusters[] | "Name: \(.DBClusterIdentifier) Engine: \(.Engine) Address: \(.Endpoint):\(.Port)" ' | grep "$RDS_IDENTIFIER_SEARCH"

--- a/bin/aurora/set-root-password
+++ b/bin/aurora/set-root-password
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: dalmatian $(basename "$(dirname "${BASH_SOURCE[0]}")") $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -r <aurora_name>          - RDS name (as defined in the Dalmatian config)"
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  echo "  -P <new_password>      - new password to set"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ];
+then
+ usage
+fi
+
+while getopts "i:e:r:P:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    r)
+      RDS_NAME=$OPTARG
+      ;;
+    P)
+      NEW_PASSWORD=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$RDS_NAME"
+  || -z "$ENVIRONMENT"
+  || -z "$NEW_PASSWORD"
+]]; then
+  usage
+fi
+
+# Remove dashes from the variables to create the RDS identifier, because dashes
+# aren't allowed in RDS identifiers. Dalmatian removes them on deployment, so we
+# need to remove them here to get the correct identifier.
+RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
+
+echo "==> Setting RDS root password in Parameter Store..."
+
+aws ssm put-parameter \
+   --name "/$INFRASTRUCTURE_NAME/$RDS_IDENTIFIER-aurora/password" \
+   --value "$NEW_PASSWORD" \
+   --type SecureString \
+   --key-id "alias/$INFRASTRUCTURE_NAME-$RDS_NAME-aurora-$ENVIRONMENT-aurora-values-ssm" \
+   --overwrite
+
+echo "==> Parameter store value set"
+echo "==> For this change to take effect, run the following from dalmatian core to deploy:"
+echo ""
+echo "    ./scripts/bin/deploy -i $INFRASTRUCTURE_NAME -e $ENVIRONMENT -S rds,hosted-zone,vpn-customer-gateway,ecs,ecs-services,elasticache-cluster,shared-loadbalancer,waf"

--- a/bin/aurora/shell
+++ b/bin/aurora/shell
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: dalmatian $(basename "$(dirname "${BASH_SOURCE[0]}")") $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -r <aurora_name>          - RDS name (as defined in the Dalmatian config)"
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  echo "  -I <ecs_insatnce_id>   - ECS instance ID to connect through (optional)"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ];
+then
+ usage
+fi
+
+while getopts "i:e:r:I:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    r)
+      RDS_NAME=$OPTARG
+      ;;
+    I)
+      ECS_INSTANCE_ID=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$RDS_NAME"
+  || -z "$ENVIRONMENT"
+]]; then
+  usage
+fi
+
+# Remove dashes from the variables to create the RDS identifier, because dashes
+# aren't allowed in RDS identifiers. Dalmatian removes them on deployment, so we
+# need to remove them here to get the correct identifier.
+RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
+
+echo "==> Retrieving RDS root password from Parameter Store..."
+
+RDS_ROOT_PASSWORD_PARAMETER=$(
+  aws ssm get-parameters \
+    --names "/$INFRASTRUCTURE_NAME/$RDS_IDENTIFIER-aurora/password" \
+    --with-decryption
+)
+RDS_ROOT_PASSWORD=$(
+  echo "$RDS_ROOT_PASSWORD_PARAMETER" \
+    | jq -r .Parameters[0].Value
+)
+
+
+
+echo "==> Getting RDS info..."
+
+RDS_INFO=$(
+  aws rds describe-db-clusters \
+    --db-cluster-identifier "$RDS_IDENTIFIER"
+)
+RDS_ENGINE=$(echo "$RDS_INFO" | jq -r .DBClusters[0].Engine)
+RDS_ROOT_USERNAME=$(echo "$RDS_INFO" | jq -r .DBClusters[0].MasterUsername)
+
+echo "Engine: $RDS_ENGINE"
+echo "Root username: $RDS_ROOT_USERNAME"
+
+if [ -z "$ECS_INSTANCE_ID" ]
+then
+  echo "==> Finding ECS instance..."
+
+  ECS_INSTANCES=$(
+    aws ec2 describe-instances \
+      --filters "Name=instance-state-code,Values=16" Name=tag:Name,Values="$INFRASTRUCTURE_NAME-$ENVIRONMENT*"
+  )
+  ECS_INSTANCE_ID=$(
+    echo "$ECS_INSTANCES" \
+      | jq -r .Reservations[0].Instances[0].InstanceId
+  )
+fi
+
+echo "ECS instance ID: $ECS_INSTANCE_ID"
+
+echo "==> Starting $RDS_ENGINE session on $RDS_IDENTIFIER..."
+set -x 
+aws ssm start-session \
+  --target "$ECS_INSTANCE_ID" \
+  --document-name "$RDS_IDENTIFIER-aurora-shell" \
+  --parameters "RootPassword=$RDS_ROOT_PASSWORD"


### PR DESCRIPTION
We are moving our databases to aurora. This adds a set of commands to manage
them in the same way as we manage RDS databases.
They are copied from the rds commands and modified to work with aurora.