### PR TITLE
List available ec2 instance ids

### DIFF
--- a/bin/rds/shell
+++ b/bin/rds/shell
@@ -10,6 +10,7 @@ usage() {
   echo "  -i <infrastructure>    - infrastructure name"
   echo "  -r <rds_name>          - RDS name (as defined in the Dalmatian config)"
   echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  echo "  -l                     - list available ec2 instance ids (optional)"
   echo "  -I <ecs_insatnce_id>   - ECS instance ID to connect through (optional)"
   exit 1
 }
@@ -20,7 +21,7 @@ then
  usage
 fi
 
-while getopts "i:e:r:I:h" opt; do
+while getopts "i:e:r:I:lh" opt; do
   case $opt in
     i)
       INFRASTRUCTURE_NAME=$OPTARG
@@ -33,6 +34,9 @@ while getopts "i:e:r:I:h" opt; do
       ;;
     I)
       ECS_INSTANCE_ID=$OPTARG
+      ;;
+    l)
+      LIST=1
       ;;
     h)
       usage
@@ -49,6 +53,16 @@ if [[
   || -z "$ENVIRONMENT"
 ]]; then
   usage
+fi
+
+if [ -n "$LIST" ];
+then
+  echo "==> Finding ECS instance..."
+  INSTANCES=$(aws ec2 describe-instances --filters Name=instance-state-code,Values=16 Name=tag:Name,Values="$INFRASTRUCTURE_NAME-$ENVIRONMENT*")
+
+  AVAILABLE_INSTANCES=$(echo "$INSTANCES" | jq -r '.Reservations[].Instances[] | (.InstanceId) + " | " + (.Tags[] | select(.Key == "Name") | .Value) + " | " + (.LaunchTime)')
+  echo "$AVAILABLE_INSTANCES"
+  exit 0
 fi
 
 # Remove dashes from the variables to create the RDS identifier, because dashes


### PR DESCRIPTION
This script is missing the option to list available ec2 instance IDs which a user would need if they want to connect manually to a specific instance. For example if the initial instance connection fails then the user can try connecting to another one by using an ec2 instance ID from the list.

https://trello.com/c/q6Lomnln/350-dalmatian-command-to-list-ec2-instances