### PR TITLE
Use caller identity to grab username

### DIFF
--- a/bin/aws/key-age
+++ b/bin/aws/key-age
@@ -20,15 +20,18 @@ while getopts "i:h" opt; do
   esac
 done
 
-read -r -p "Enter your AWS username: " username
+if [ -z "$AWS_CALLER_IDENTITY_USERNAME" ];
+then
+  read -r -p "Enter your AWS username: " AWS_CALLER_IDENTITY_USERNAME
+fi
 
 # Get access key metadata for the user
-metadata=$(aws iam list-access-keys --user-name "$username")
+metadata=$(aws iam list-access-keys --user-name "$AWS_CALLER_IDENTITY_USERNAME")
 
 # Check if any access keys were found
 if [[ $(echo "$metadata" | jq '.AccessKeyMetadata | length') == 0 ]]
 then
-    echo "No access keys found for user $username"
+    echo "No access keys found for user $AWS_CALLER_IDENTITY_USERNAME"
     exit 1
 fi
 

--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -196,6 +196,10 @@ export AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY
 export AWS_SESSION_TOKEN
 
+AWS_CALLER_IDENTITY_ARN="$(aws sts get-caller-identity | jq '.Arn')"
+IFS='/' read -r -a array <<< "$AWS_CALLER_IDENTITY_ARN"
+export AWS_CALLER_IDENTITY_USERNAME="${array[2]%?}"
+
 # Check if the assume role credentials have expired
 if [ -f "$DALMATIAN_ASSUME_MAIN_ROLE_CREDENTIALS_FILE" ]
 then


### PR DESCRIPTION
The Caller Identity is set before Dalmatian assumes a role to operate on infrastructure. This should be the actor's AWS username that we can pass into the `aws iam` script