### PR TITLE
Add list-services-by-buildspec command

### DIFF
--- a/bin/config/list-services-by-buildspec
+++ b/bin/config/list-services-by-buildspec
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+"$APP_ROOT/bin/dalmatian-refresh-config" > /dev/null
+
+usage() {
+  echo "List all services with a given buildspec"
+  echo "e.g. dalmatian config $(basename "$0") -b dalmatian_core_buildspec_saluki"
+  echo "Usage: $(basename "$0") <infrastructure name [OPTIONAL]>" 1>&2
+  echo "  -b                     - buildspec e.g. dalmatian_core_buildspec_saluki"
+  echo "  -i                     - infrastructure name (optional)"
+  echo "  -h                     - help"
+  exit 1
+}
+
+INFRASTRUCTURE_NAME=""
+while getopts "b:i:h" opt; do
+  case $opt in
+    b)
+      BUILDSPEC=$OPTARG
+      ;;
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+
+if [[ -z "$BUILDSPEC" ]]
+then
+  usage
+fi
+
+INFRAS=$(yq e -o=json ".infrastructures" "$APP_ROOT/bin/tmp/dalmatian-config/dalmatian.yml")
+
+if [ -z "$INFRASTRUCTURE_NAME" ]
+then
+  echo "$INFRAS" | jq -r --arg b "$BUILDSPEC" '. as $infras | keys[] as $infra_name | $infras[$infra_name].services[] | select(.buildspec == $b) | "\($infra_name) \(.name)"'
+else
+  echo "$INFRAS" | jq -r --arg i "$INFRASTRUCTURE_NAME" --arg b "$BUILDSPEC" '. as $infras | keys[] as $infra_name | $infras[$infra_name].services[] | select($infra_name == $i) | select(.buildspec == $b) | "\($infra_name) \(.name)"'
+fi


### PR DESCRIPTION

Raising this PR again, because the new file is no longer in `main`, I guess due to a bad merge.

Add a new command to list services in the infrastructure by buildspec. For example, to list all WordPress services:

    dalmatian config list-services-by-buildspec -b dalmatian_core_buildspec_saluki

Optionally, services can be listed for a single infrastructure:

    dalmatian config list-services-by-buildspec -b dalmatian_core_buildspec_saluki -i dxw-govpress

Note that this command cannot be used to list services which do not have a buildspec.

Output appears in the following format:

    infra service\n...

e.g

    bbb bbb-fh-next
    dfe-fh web
    dfe-skills web
    dxw-govpress advisories
    dxw-govpress af-covenant
    ...