### PR TITLE
Fix: Variable export, spurious file creation, debugging

### DIFF
--- a/bin/configure-commands/setup
+++ b/bin/configure-commands/setup
@@ -153,7 +153,7 @@ echo ""
 
 echo "-- AWS SSO configration --"
 read_prompt_with_setup_default -p "AWS SSO start URL" -d "aws_sso.start_url" -s
-read_prompt_with_setup_default -p "AWS SSO Region" -d "aws_sso.region" > -s
+read_prompt_with_setup_default -p "AWS SSO Region" -d "aws_sso.region" -s
 read_prompt_with_setup_default -p "AWS SSO Default administrative role name" -d "aws_sso.default_admin_role_name" -s
 read_prompt_with_setup_default -p "AWS SSO Registration Scopes" -d "aws_sso.registration_scopes" -s
 echo ""

--- a/bin/deploy/account-bootstrap
+++ b/bin/deploy/account-bootstrap
@@ -60,15 +60,15 @@ do
     WORKSPACE_EXISTS=1
     terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" workspace select "$workspace"
     ACCOUNT_NAME=$(echo "$workspace" | cut -d'-' -f5-)
-    echo "Account Name: $ACCOUNT_NAME"
     if [[ "$ACCOUNT_NAME" == "dalmatian-main" ]]; then
-      export TF_VAR_enable_s3_tfvars=true
+      TF_VAR_enable_s3_tfvars=true
       TF_VAR_tfvars_s3_tfvars_files="$(cat "$CONFIG_TFVARS_PATHS_FILE")"
-      export TF_VAR_tfvars_s3_tfvars_files
     else
       TF_VAR_enable_s3_tfvars=false
       TF_VAR_tfvars_s3_tfvars_files="{}"
     fi
+    export TF_VAR_enable_s3_tfvars
+    export TF_VAR_tfvars_s3_tfvars_files
     export AWS_PROFILE="$ACCOUNT_NAME"
     terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" apply \
       -var-file="$CONFIG_TFVARS_DIR/000-terraform.tfvars" \


### PR DESCRIPTION
* Exports the `TF_VAR_enable_s3_tfvars` and `TF_VAR_tfvars_s3_tfvars_files` correctly
* Fixes the accidental creation of a file names `-s`
* Removes left over debugging