### PR TITLE
Allow force login

### DIFF
--- a/bin/aws-sso/login
+++ b/bin/aws-sso/login
@@ -16,11 +16,14 @@ if [ $# -eq 0 ]
 then
  usage
 fi
-
-while getopts "p:h" opt; do
+FORCE_RELOG=0
+while getopts "p:fh" opt; do
   case $opt in
     p)
       AWS_SSO_PROFILE=$OPTARG
+      ;;
+    f)
+      FORCE_RELOG=1
       ;;
     h)
       usage


### PR DESCRIPTION
* The `dalmatian aws-sso login` command will only run the login process if the token has expired. In the case that this logic fails, `-f` can be used to login anyway