### PR TITLE
Extract all bash functions to a single file

### DIFF
--- a/bin/aws-sso/generate-config
+++ b/bin/aws-sso/generate-config
@@ -4,27 +4,6 @@
 set -e
 set -o pipefail
 
-append_sso_config_file ()
-{
-  config_file="$1"
-  profile_name="$2"
-  sso_start_url="$3"
-  sso_region="$4"
-  sso_account_id="$5"
-  sso_role_name="$6"
-  region="$7"
-
-  cat <<EOT >> "$config_file"
-[profile $profile_name]
-sso_start_url = $sso_start_url
-sso_region = $sso_region
-sso_account_id = $sso_account_id
-sso_role_name = $sso_role_name
-region = $region
-  
-EOT
-}
-
 echo "==> Generating Dalmatian SSO configuration ..."
 
 AWS_SSO_START_URL="$(jq -r '.aws_sso.start_url' < "$CONFIG_SETUP_JSON_FILE")"

--- a/bin/configure-commands/setup
+++ b/bin/configure-commands/setup
@@ -28,58 +28,6 @@ usage() {
   exit 1
 }
 
-read_prompt_with_setup_default() {
-  OPTIND=1
-  DEFAULT=""
-  SILENT=0
-  while getopts "p:d:s" opt; do
-    case $opt in
-      p)
-        PROMPT="$OPTARG"
-        ;;
-      d)
-        DEFAULT="$OPTARG"
-        ;;
-      s)
-        SILENT=1
-        ;;
-      *)
-        echo "Invalid usage"
-        ;;
-    esac
-  done
-  if [ "$DEFAULT" != "" ]
-  then
-    PROMPT_DEFAULT=$(jq -r --arg index "$DEFAULT" 'getpath($index / ".")' < "$CONFIG_SETUP_JSON_FILE")
-    if [[
-      -n "$PROMPT_DEFAULT" &&
-      "$PROMPT_DEFAULT" != "null"
-    ]]
-    then
-      PROMPT="$PROMPT [$PROMPT_DEFAULT]"
-    fi
-  fi
-  read -rp "$PROMPT: " VALUE
-  if [ "$VALUE" == "" ]
-  then
-    PROMPT_RESULT="$PROMPT_DEFAULT"
-  else
-    PROMPT_RESULT="$VALUE"
-  fi
-  SETUP_JSON=$(
-    jq -r \
-      --arg index "$DEFAULT" \
-      --arg value "$PROMPT_RESULT" \
-      'getpath($index / ".") |= $value' \
-      < "$CONFIG_SETUP_JSON_FILE"
-  )
-  echo "$SETUP_JSON" > "$CONFIG_SETUP_JSON_FILE"
-  if [ "$SILENT" == "0" ]
-  then
-    echo "$PROMPT_RESULT"
-  fi
-}
-
 SETUP_FILE_PATH=""
 while getopts "f:u:h" opt; do
   case $opt in

--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -23,6 +23,12 @@ fi
 APP_ROOT="$( cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd -P)"
 export APP_ROOT
 
+source "$APP_ROOT/lib/bash-functions.sh"
+while IFS='' read -r function_name
+do
+  export -f "${function_name?}"
+done < <(grep "^function" "$APP_ROOT/lib/bash-functions.sh" | cut -d" " -f2)
+
 if [ "${1:0:1}" == "-" ]
 then
   while getopts "lh" opt; do

--- a/bin/setup
+++ b/bin/setup
@@ -7,52 +7,11 @@ set -o pipefail
 # @usage yes_no "Continue with setup? (Y/n)" "Y"
 # @param $1 Message to prompt the user with
 # @param $2 The default value if the user does not specify
-yes_no() {
-  local MESSAGE
-  local DEFAULT
 
-  MESSAGE="${1-"Continue? (Y/n)"}"
-  DEFAULT="${2-"Y"}"
+APP_ROOT="$( cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd -P)"
+export APP_ROOT
 
-  while true; do
-    read -rep "${MESSAGE} [$DEFAULT]: " CHOICE
-    CHOICE=${CHOICE:-$DEFAULT}
-    echo
-    case "${CHOICE:0:1}" in
-      [yY] )
-        return 0 # true
-        ;;
-      [nN] )
-        return 1 # false
-        ;;
-      * )
-        echo "Please answer Y or N"
-        ;;
-    esac
-  done
-}
-
-# Set up a handy repeatable error output function that uses `stderr`
-#
-# @usage err "A problem happened!"
-# @param $* Any information to pass into stderr
-err() {
-  echo "[!] Error: $*" >&2
-}
-
-# Check to see if a binary is installed on the system
-#
-# @usage  is_installed "oathtool"
-# @param  $1 binary name
-# @export $IS_INSTALLED boolean Whether the binary was found
-is_installed() {
-  if ! which -s "$1" || ! type -p "$1" > /dev/null; then
-    err "$1 was not detected in your \$PATH"
-    return 1 # false
-  fi
-
-  return 0 # true
-}
+source "$APP_ROOT/lib/bash-functions.sh"
 
 # Check to see if Homebrew is installed, and prompt to install it if it isn't
 if ! is_installed "brew"; then

--- a/lib/bash-functions.sh
+++ b/lib/bash-functions.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Prompt the user with a binary question
+#
+# @usage yes_no "Continue with setup? (Y/n)" "Y"
+# @param $1 Message to prompt the user with
+# @param $2 The default value if the user does not specify
+function yes_no {
+  local MESSAGE
+  local DEFAULT
+
+  MESSAGE="${1-"Continue? (Y/n)"}"
+  DEFAULT="${2-"Y"}"
+
+  while true; do
+    read -rep "${MESSAGE} [$DEFAULT]: " CHOICE
+    CHOICE=${CHOICE:-$DEFAULT}
+    echo
+    case "${CHOICE:0:1}" in
+      [yY] )
+        return 0 # true
+        ;;
+      [nN] )
+        return 1 # false
+        ;;
+      * )
+        echo "Please answer Y or N"
+        ;;
+    esac
+  done
+}
+
+# Set up a handy repeatable error output function that uses `stderr`
+#
+# @usage err "A problem happened!"
+# @param $* Any information to pass into stderr
+function err {
+  echo "[!] Error: $*" >&2
+}
+
+# Check to see if a binary is installed on the system
+#
+# @usage  is_installed "oathtool"
+# @param  $1 binary name
+# @export $IS_INSTALLED boolean Whether the binary was found
+function is_installed {
+  if ! which -s "$1" || ! type -p "$1" > /dev/null; then
+    err "$1 was not detected in your \$PATH"
+    return 1 # false
+  fi
+
+  return 0 # true
+}
+
+# Dalmatian specific function
+# Ask for a value from the user, and add it to setup.json
+# If the value already exists in setup.json, provide it as a default
+function read_prompt_with_setup_default {
+  OPTIND=1
+  DEFAULT=""
+  SILENT=0
+  while getopts "p:d:s" opt; do
+    case $opt in
+      p)
+        PROMPT="$OPTARG"
+        ;;
+      d)
+        DEFAULT="$OPTARG"
+        ;;
+      s)
+        SILENT=1
+        ;;
+      *)
+        echo "Invalid usage"
+        ;;
+    esac
+  done
+  if [ "$DEFAULT" != "" ]
+  then
+    PROMPT_DEFAULT=$(jq -r --arg index "$DEFAULT" 'getpath($index / ".")' < "$CONFIG_SETUP_JSON_FILE")
+    if [[
+      -n "$PROMPT_DEFAULT" &&
+      "$PROMPT_DEFAULT" != "null"
+    ]]
+    then
+      PROMPT="$PROMPT [$PROMPT_DEFAULT]"
+    fi
+  fi
+  read -rp "$PROMPT: " VALUE
+  if [ "$VALUE" == "" ]
+  then
+    PROMPT_RESULT="$PROMPT_DEFAULT"
+  else
+    PROMPT_RESULT="$VALUE"
+  fi
+  SETUP_JSON=$(
+    jq -r \
+      --arg index "$DEFAULT" \
+      --arg value "$PROMPT_RESULT" \
+      'getpath($index / ".") |= $value' \
+      < "$CONFIG_SETUP_JSON_FILE"
+  )
+  echo "$SETUP_JSON" > "$CONFIG_SETUP_JSON_FILE"
+  if [ "$SILENT" == "0" ]
+  then
+    echo "$PROMPT_RESULT"
+  fi
+}
+
+# Dalmatian specific function
+# Appends AWS sso config to the provided
+# configuration file
+function append_sso_config_file {
+  config_file="$1"
+  profile_name="$2"
+  sso_start_url="$3"
+  sso_region="$4"
+  sso_account_id="$5"
+  sso_role_name="$6"
+  region="$7"
+
+  cat <<EOT >> "$config_file"
+[profile $profile_name]
+sso_start_url = $sso_start_url
+sso_region = $sso_region
+sso_account_id = $sso_account_id
+sso_role_name = $sso_role_name
+region = $region
+
+EOT
+}


### PR DESCRIPTION
* This allows the functions to be reused
* The bash-functions.sh file has been sourced by the `bin/setup` command
* It is also sourced in the `bin/dalmatian` script, and then all functions exported, so that they are available in subsequent scripts
* To allow for the functions to be easily exported (without listing them all individually), the function syntax has changed from the prefered `function_name() {}` format, to `function function_name {}`. This is so that we can just `grep "^function"` to retrieve the function names, and export each one - which allows us to just add new functions to the file, and expect them to be available.