### PR TITLE
Prompt the user to complete the missing part of the command

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -322,5 +322,19 @@ then
   . "$APP_ROOT/bin/aws/assume-infrastructure-role" -i "$INFRASTRUCTURE_NAME"
 fi
 
+# If no COMMAND was specified, and SUBCOMMAND isn't an executable script
+if [[ -z "${COMMAND}" && ! -f "${SUBCOMMAND}" ]] || [[ ! -f "$APP_ROOT/bin/$SUBCOMMAND/$COMMAND" ]]; then
+  err "Command not found: $(basename "${0}") ${SUBCOMMAND} ${COMMAND:=""}"
+
+  echo
+  echo "Usage:"
+
+  while IFS=  read -r -d $'\0'; do
+    echo "  $(basename "${0}") ${SUBCOMMAND} $(basename "${REPLY}")"
+  done < <(find "${APP_ROOT}/bin/$SUBCOMMAND" -maxdepth 1 -type f -print0)
+
+  exit 1
+fi
+
 # Run specified command with args
 "$APP_ROOT/bin/$SUBCOMMAND/$COMMAND" "${COMMAND_ARGS[@]}"


### PR DESCRIPTION
If a human inputs an incorrect subcommand or omits it entirely, we should remind them of the list of available commands rather than just shunting them a generic shell error

Before:
```bash
$ dalmatian service out                         
/Users/ash/sites/dalmatian-tools/bin/dalmatian: line 324: /Users/ash/sites/dalmatian-tools/bin/service/out: No such file or directory
```

After:
```bash
$ dalmatian service out 

[!] Error: Command not found: dalmatian service out

Usage:
  dalmatian service container-access
  dalmatian service show-deployment-status
  dalmatian service set-environment-variable
  dalmatian service deploy
  dalmatian service list-container-placement
  dalmatian service ecr-vulnerabilities
  dalmatian service deploy-status
  dalmatian service get-environment-variable
  dalmatian service delete-environment-variable
  dalmatian service pull-image
  dalmatian service run-container-command
  dalmatian service deploy-build-logs
  dalmatian service restart-containers
  dalmatian service list-environment-variables
  dalmatian service list-domains
  dalmatian service list-pipelines
```