### PR TITLE
Fix terraform-dependencies set-global-tfvars command

### DIFF
--- a/bin/terraform-dependencies/set-global-tfvars
+++ b/bin/terraform-dependencies/set-global-tfvars
@@ -26,69 +26,69 @@ PROJECT_NAME_HASH="$(echo -n "$PROJECT_NAME" | sha1sum | head -c 6)"
 TFVARS_BUCKET_NAME="$PROJECT_NAME_HASH-tfvars"
 TFVARS_PATHS_JSON="$(jq -r < "$CONFIG_TFVARS_PATHS_FILE")"
 TFVARS_DIR="${CONFIG_TFVARS_DIR/$HOME/~}"
-CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE_EXISTS=0
+CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE_EXISTS=0
 
-echo "==> Checking $CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE file ..."
+echo "==> Checking $CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE file ..."
 
-if aws s3api head-object --bucket "$TFVARS_BUCKET_NAME" --key "$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE" > /dev/null 2>&1
+if aws s3api head-object --bucket "$TFVARS_BUCKET_NAME" --key "$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" > /dev/null 2>&1
 then
-  aws s3 cp "s3://$TFVARS_BUCKET_NAME/$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE" "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" > /dev/null
-  if ! diff "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" "$CONFIG_TFVARS_DIR/$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE" > /dev/null
+  aws s3 cp "s3://$TFVARS_BUCKET_NAME/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" > /dev/null
+  if ! diff "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" "$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" > /dev/null
   then
-    echo "The remote $CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE file is different than your local cached copy."
+    echo "The remote $CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE file is different than your local cached copy."
     echo "This is either because the remote copy has been updated, or you have already edited your local copy"
     echo "What do you want to do?"
     echo "1) Edit my local copy"
     echo "2) Use the remote copy and edit"
     echo "3) Show the diff"
     read -rp "?: " DIFF_OPTION
-    if [ "$DIFF_OPTION" == "2" ]
+    if [ "$DIFF_OPTION" == "1" ]
     then
-      mv "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" "$CONFIG_TFVARS_DIR/$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE"
-    fi
-    if [ "$DIFF_OPTION" == "3" ]
+      rm "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars"
+    elif [ "$DIFF_OPTION" == "2" ]
     then
-      diff "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" "$CONFIG_TFVARS_DIR/$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE"
+      mv "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" "$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE"
+    elif [ "$DIFF_OPTION" == "3" ]
+    then
+      diff "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" "$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE"
       rm "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars"
       exit 0
     fi
-    rm "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars"
   fi
-  rm "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars"
-  CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE_EXISTS=1
+  CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE_EXISTS=1
 fi
 
 GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_ADD_TO_PATHS_JSON=0
-if [ "$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE_EXISTS" == "0" ]
+if [ "$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE_EXISTS" == "0" ]
 then
-  echo "==> $CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE doesn't exist ..."
-  read -rp "Do you want to create the $CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE file now? [y/n]: " CREATE_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE
+  echo "==> $CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE doesn't exist ..."
+  read -rp "Do you want to create the $CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE file now? [y/n]: " CREATE_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE
   if [[
     "$CREATE_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" == "y"
   ]]
   then
-    cp "$APP_ROOT/data/tfvars-templates/account-bootstrap.tfvars" "$CONFIG_TFVARS_DIR/$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE"
-    $EDITOR "$CONFIG_TFVARS_DIR/$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE"
+    cp "$APP_ROOT/data/tfvars-templates/account-bootstrap.tfvars" "$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE"
+    $EDITOR "$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE_EXISTS"
     GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_ADD_TO_PATHS_JSON=1
   fi
 fi
 
-if [ "$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE_EXISTS" == "1" ]
+if [ "$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE_EXISTS" == "1" ]
 then
-  $EDITOR "$CONFIG_TFVARS_DIR/$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE"
+  $EDITOR "$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE"
 fi
 
 if [ "$GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_ADD_TO_PATHS_JSON" == "1" ]
 then
   TFVARS_PATHS_JSON=$(echo "$TFVARS_PATHS_JSON" | jq -c \
-    --arg global_account_bootstrap_tfvars_file "$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE" \
-    --arg global_account_bootstrap_tfvars_path "$TFVARS_DIR/$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE" \
+    --arg global_account_bootstrap_tfvars_file "$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" \
+    --arg global_account_bootstrap_tfvars_path "$TFVARS_DIR/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" \
     '. += { "global-account-bootstrap": { "path": $global_account_bootstrap_tfvars_path, "key": $global_account_bootstrap_tfvars_file } }')
 fi
 
 echo "$TFVARS_PATHS_JSON" > "$CONFIG_TFVARS_PATHS_FILE"
 
-echo "==> $CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE edited!"
+echo "==> $CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE edited!"
 
 MAIN_DALMATIAN_ACCOUNT_ID="$(jq -r '.main_dalmatian_account_id' < "$CONFIG_SETUP_JSON_FILE")"
 DEFAULT_REGION="$(jq -r '.default_region' < "$CONFIG_SETUP_JSON_FILE")"


### PR DESCRIPTION
* It was using the `CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE` variable rather than the `CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE` variable, which contains the filename of the global tfavrs file.