### PR TITLE
Bump terraform-dxw-dalmatian-account-bootstrap module to v0.2.1

### DIFF
--- a/bin/terraform-dependencies/clone
+++ b/bin/terraform-dependencies/clone
@@ -11,7 +11,7 @@ usage() {
   exit 1
 }
 
-ACCOUNT_BOOTSTRAP_VERSION="v0.2.0"
+ACCOUNT_BOOTSTRAP_VERSION="v0.2.1"
 while getopts "a:h" opt; do
   case $opt in
     a)
@@ -33,6 +33,7 @@ then
   rm -rf "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR"
 fi
 
+echo "==> Cloning dxw/terraform-dxw-dalmatian-account-bootstrap $ACCOUNT_BOOTSTRAP_VERSION ..."
 git clone \
   --depth 1 \
   --branch "$ACCOUNT_BOOTSTRAP_VERSION" \


### PR DESCRIPTION
* Module updates: https://github.com/dxw/terraform-dxw-dalmatian-account-bootstrap/releases/tag/v0.2.1
* The `terraform-dependencies clone` command now outputs the version it's cloning