### PR TITLE
Add one to the ACL rule count to get the next priority number.

### DIFF
--- a/bin/waf/set-ip-rule
+++ b/bin/waf/set-ip-rule
@@ -117,7 +117,7 @@ ACL_RULES_COUNT=$(echo "$ACL_RULES" | jq length)
 echo "[!] Found $ACL_RULES_COUNT existing rules in this ACL"
 
 # Rule priorities must be unique so simply +1 to the number of existing rules
-PRIORITY_COUNT=$ACL_RULES_COUNT
+PRIORITY_COUNT=$((ACL_RULES_COUNT + 1))
 
 echo "[!] New rule will be given Priority $PRIORITY_COUNT"
 


### PR DESCRIPTION
This was missing from the script and stopped us deploying new rules.

It produces the following error.

```
An error occurred (WAFInvalidParameterException) when calling the UpdateWebACL operation: Error reason: You have a duplicate priority. Priorities must be unique., field: RULE, parameter: 5
```