### PR TITLE
Fix tfenv `-chdir` usage

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
+brew "coreutils"
 brew "awscli"
 brew "jq"
 brew "yq"

--- a/bin/aws-sso/account-init
+++ b/bin/aws-sso/account-init
@@ -60,14 +60,14 @@ do
   then
     WORKSPACE_EXISTS=1
   fi
-done < <(terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" workspace list)
+done < <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)
 
 if [ "$WORKSPACE_EXISTS" == "1" ]
 then
   echo "==> $NEW_WORKSPACE_NAME workspace exists"
-  terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" workspace select "$NEW_WORKSPACE_NAME"
+  terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace select "$NEW_WORKSPACE_NAME"
 else
-  terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" workspace new "$NEW_WORKSPACE_NAME"
+  terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace new "$NEW_WORKSPACE_NAME"
 fi
 
 "$APP_ROOT/bin/dalmatian" aws-sso generate-config

--- a/bin/aws-sso/generate-config
+++ b/bin/aws-sso/generate-config
@@ -60,4 +60,4 @@ do
       "$DALMATIAN_ACCOUNT_ADMIN_ROLE_NAME" \
       "$SSO_CONFIG_REGION"
   fi
-done < <(terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" workspace list)
+done < <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)

--- a/bin/deploy/account-bootstrap
+++ b/bin/deploy/account-bootstrap
@@ -81,7 +81,7 @@ do
   ]]
   then
     WORKSPACE_EXISTS=1
-    terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" workspace select "$workspace"
+    terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace select "$workspace"
     ACCOUNT_NAME=$(echo "$workspace" | cut -d'-' -f5-)
     if [[ "$ACCOUNT_NAME" == "dalmatian-main" ]]; then
       TF_VAR_enable_s3_tfvars=true
@@ -93,13 +93,13 @@ do
     export TF_VAR_enable_s3_tfvars
     export TF_VAR_tfvars_s3_tfvars_files
     export AWS_PROFILE="$ACCOUNT_NAME"
-    terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" "${OPTIONS[@]}" \
+    terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" "${OPTIONS[@]}" \
       -var-file="$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE" \
       -var-file="$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" \
       -var-file="$CONFIG_TFVARS_DIR/000-terraform.tfvars" \
       -var-file="$CONFIG_TFVARS_DIR/100-$workspace.tfvars"
   fi
-done 9< <(terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" workspace list)
+done 9< <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)
 
 if [ "$WORKSPACE_EXISTS" == "0" ]
 then

--- a/bin/deploy/list-accounts
+++ b/bin/deploy/list-accounts
@@ -12,4 +12,4 @@ do
   then
     echo "$workspace"
   fi
-done < <(terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" workspace list)
+done < <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)

--- a/bin/terraform-dependencies/get-tfvars
+++ b/bin/terraform-dependencies/get-tfvars
@@ -148,6 +148,6 @@ do
         '. += { "\($workspace_name)": { "path": $workspace_tfvars_path, "key": $workspace_tfvars_file } }')
     fi
   fi
-done 9< <(terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" workspace list)
+done 9< <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)
 
 echo "$TFVARS_PATHS_JSON" > "$CONFIG_TFVARS_PATHS_FILE"

--- a/bin/terraform-dependencies/initialise
+++ b/bin/terraform-dependencies/initialise
@@ -12,16 +12,16 @@ usage() {
   exit 1
 }
 
-OPTIONS=(
+ACCOUNT_BOOTSTRAP_OPTIONS=(
   "-backend-config=$CONFIG_ACCOUNT_BOOTSTRAP_BACKEND_VARS_FILE"
 )
 while getopts "ruh" opt; do
   case $opt in
     r)
-      OPTIONS+=("-reconfigure")
+      ACCOUNT_BOOTSTRAP_OPTIONS+=("-reconfigure")
       ;;
     u)
-      OPTIONS+=("-upgrade")
+      ACCOUNT_BOOTSTRAP_OPTIONS+=("-upgrade")
       ;;
     h)
       usage
@@ -34,4 +34,4 @@ done
 
 echo "==> Attempting Terraform init ..."
 export AWS_PROFILE="dalmatian-main"
-terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" init "${OPTIONS[@]}"
+terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" init "${ACCOUNT_BOOTSTRAP_OPTIONS[@]}"

--- a/bin/terraform-dependencies/set-tfvars
+++ b/bin/terraform-dependencies/set-tfvars
@@ -48,7 +48,7 @@ then
       WORKSPACES+=("$workspace")
       echo "$WORKSPACE_INDEX) $workspace"
     fi
-  done < <(terraform -chdir="$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR" workspace list)
+  done < <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)
 
   while true
   do


### PR DESCRIPTION
* When using the `-chdir` flag with terraform, tfenv doesn't respect the `.terraform-version` file if the paht is absolute: https://github.com/tfutils/tfenv/issues/354
* This changes the path so that it is relative