### PR TITLE
Remove experimental commands warning

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -137,9 +137,6 @@ if [[
   "$SUBCOMMAND" == "deploy"
 ]]
 then
-  echo "-- WARNING: Experimental commands under development --"
-  echo ""
-
   export CONFIG_DIR="$HOME/.config/dalmatian"
   export CONFIG_SETUP_JSON_FILE="$CONFIG_DIR/setup.json"
   export CONFIG_CACHE_DIR="$CONFIG_DIR/.cache"


### PR DESCRIPTION
* Having this output creates too much noise, and prevents being able to parse output from other commands. The commands have been tested and are usable in their current state