### PR TITLE
Add quiet mode to `run-terraform-command`

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -112,6 +112,16 @@ fi
 SUBCOMMAND="$1"
 COMMAND="$2"
 COMMAND_ARGS=( "${@:3}" )
+QUIET_MODE=0
+for i in "${!COMMAND_ARGS[@]}"
+do
+  if [ "${COMMAND_ARGS[i]}" == "-q" ]
+  then
+    QUIET_MODE=1
+    unset "COMMAND_ARGS[i]"
+  fi
+done
+export QUIET_MODE
 
 if [[ -z "$SUBCOMMAND" && -z "$COMMAND" ]]
 then

--- a/bin/terraform-dependencies/run-terraform-command
+++ b/bin/terraform-dependencies/run-terraform-command
@@ -9,6 +9,7 @@ usage() {
   echo "  -c <command>     - Terraform command to run (Quoted)"
   echo "  -a               - Run against the account bootstrap terraform project"
   echo "  -i               - Run against the infrastructure terraform project"
+  echo "  -q               - Quiet mode (Only outputs the terraform command output)"
   echo "  -h               - help"
   exit 1
 }
@@ -81,7 +82,6 @@ then
   if [ "$TERRAFORM_PROJECT" == "account-bootstrap" ]
   then
     ACCOUNT_NAME=$(echo "$CURRENT_WORKSPACE" | cut -d'-' -f5-)
-    echo "$ACCOUNT_NAME"
     if [[ "$ACCOUNT_NAME" == "dalmatian-main" ]]
     then
       TF_VAR_enable_s3_tfvars=true
@@ -110,10 +110,13 @@ then
   fi
 fi
 
-echo "==> Running command:"
-echo "terraform -chdir=$(grealpath --relative-to="$PWD" "$RUN_DIR")"
-echo "${OPTIONS[@]}" | sed "s/ / \\\ \n/g" | sed "s/^/  /g"
-echo ""
+if [ "$QUIET_MODE" == 0 ]
+then
+  echo "==> Running command:"
+  echo "terraform -chdir=$(grealpath --relative-to="$PWD" "$RUN_DIR")"
+  echo "${OPTIONS[@]}" | sed "s/ / \\\ \n/g" | sed "s/^/  /g"
+  echo ""
+fi
 
 # shellcheck disable=SC2068
 terraform -chdir="$(grealpath --relative-to="$PWD" "$RUN_DIR")" ${OPTIONS[@]}

--- a/bin/util/generate-four-words
+++ b/bin/util/generate-four-words
@@ -8,17 +8,14 @@ usage() {
   echo 'Generate a password that is suitable for use in basic auth'
   echo 'e.g. penguin-maps-thoughts-pencil'
   echo "Usage: $(basename "$0") [OPTIONS] <command>" 1>&2
-  echo "  -q                     - quiet"
+  echo "  -q                     - Quiet mode"
   echo "  -h                     - help"
 
   exit 1
 }
 
-while getopts "qh" opt; do
+while getopts "h" opt; do
   case $opt in
-    q)
-      QUIET=true
-      ;;
     h)
       usage
       ;;
@@ -28,7 +25,7 @@ while getopts "qh" opt; do
   esac
 done
 
-if [ ! "$QUIET" == "true" ]
+if [ "$QUIET_MODE" == "0" ]
 then
   echo "Please note that the phrases generated here should not be used as login"
   echo "passwords or to hide secrets. Please use 1Password in those cicumstances."


### PR DESCRIPTION
* By default, it's more useful to show what command is going to be ran, as the script adds extra parameters to the command that a user inputs (eg. adding the var files and chdir parameters).
* This adds a quiet mode (`-q`) so that this command can be used within the other scripts, reducing the amount of code duplication when needing to load the var files etc.
* The `-q` flag is detected and removed in the top `dalmatian` script, setting the `QUIET_MODE=1` environment variable, so it can be used across other scripts