### PR TITLE
Use `run-terraform-command` throughout the scripts

### DIFF
--- a/bin/aws-sso/account-init
+++ b/bin/aws-sso/account-init
@@ -60,14 +60,14 @@ do
   then
     WORKSPACE_EXISTS=1
   fi
-done < <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)
+done < <("$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace list" -a -q)
 
 if [ "$WORKSPACE_EXISTS" == "1" ]
 then
   echo "==> $NEW_WORKSPACE_NAME workspace exists"
-  terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace select "$NEW_WORKSPACE_NAME"
+  "$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace select $NEW_WORKSPACE_NAME" -a -q
 else
-  terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace new "$NEW_WORKSPACE_NAME"
+  "$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace new $NEW_WORKSPACE_NAME" -a -q
 fi
 
 "$APP_ROOT/bin/dalmatian" aws-sso generate-config

--- a/bin/aws-sso/generate-config
+++ b/bin/aws-sso/generate-config
@@ -60,4 +60,4 @@ do
       "$DALMATIAN_ACCOUNT_ADMIN_ROLE_NAME" \
       "$SSO_CONFIG_REGION"
   fi
-done < <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)
+done < <("$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace list" -a -q)

--- a/bin/deploy/account-bootstrap
+++ b/bin/deploy/account-bootstrap
@@ -81,25 +81,10 @@ do
   ]]
   then
     WORKSPACE_EXISTS=1
-    terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace select "$workspace"
-    ACCOUNT_NAME=$(echo "$workspace" | cut -d'-' -f5-)
-    if [[ "$ACCOUNT_NAME" == "dalmatian-main" ]]; then
-      TF_VAR_enable_s3_tfvars=true
-      TF_VAR_tfvars_s3_tfvars_files="$(cat "$CONFIG_TFVARS_PATHS_FILE")"
-    else
-      TF_VAR_enable_s3_tfvars=false
-      TF_VAR_tfvars_s3_tfvars_files="{}"
-    fi
-    export TF_VAR_enable_s3_tfvars
-    export TF_VAR_tfvars_s3_tfvars_files
-    export AWS_PROFILE="$ACCOUNT_NAME"
-    terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" "${OPTIONS[@]}" \
-      -var-file="$CONFIG_TFVARS_DEFAULT_ACCOUNT_BOOTSRAP_FILE" \
-      -var-file="$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" \
-      -var-file="$CONFIG_TFVARS_DIR/000-terraform.tfvars" \
-      -var-file="$CONFIG_TFVARS_DIR/100-$workspace.tfvars"
+    "$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace select $workspace" -a -q
+    "$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "${OPTIONS[@]}" -a -q
   fi
-done 9< <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)
+done 9< <("$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace list" -a -q)
 
 if [ "$WORKSPACE_EXISTS" == "0" ]
 then

--- a/bin/deploy/infrastructure
+++ b/bin/deploy/infrastructure
@@ -94,7 +94,7 @@ do
   then
     WORKSPACE_EXISTS=1
   fi
-done < <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_INFRASTRUCTURE_TERRAFORM_DIR")" workspace list)
+done < <("$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace list" -i -q)
 
 if [[
   "$WORKSPACE_EXISTS" == "0" &&
@@ -108,7 +108,7 @@ then
   then
     exit 0
   fi
-  terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_INFRASTRUCTURE_TERRAFORM_DIR")" workspace new "$DALMATIAN_ACCOUNT-$INFRASTRUCTURE_NAME-$ENVIRONMENT_NAME"
+  "$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace new $DALMATIAN_ACCOUNT-$INFRASTRUCTURE_NAME-$ENVIRONMENT_NAME" -i -q
 fi
 
 DEPLOY_ALL="y"
@@ -161,14 +161,7 @@ do
     -n "$workspace"
   ]]
   then
-    terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_INFRASTRUCTURE_TERRAFORM_DIR")" workspace select "$workspace"
-    ACCOUNT_NAME=$(echo "$workspace" | cut -d'-' -f5- | rev | cut -d'-' -f3- | rev)
-    export AWS_PROFILE="$ACCOUNT_NAME"
-    TF_VAR_infrastructure_name="$(echo "$workspace" | rev | cut -d'-' -f1 | rev)"
-    TF_VAR_environment="$(echo "$workspace" | rev | cut -d'-' -f1 | rev)"
-    export TF_VAR_infrastructure_name
-    export TF_VAR_environment
-    terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_INFRASTRUCTURE_TERRAFORM_DIR")" "${OPTIONS[@]}" \
-      -var-file="$CONFIG_TFVARS_DIR/000-terraform.tfvars"
+    "$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace select $workspace" -i -q
+    "$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "${OPTIONS[@]}" -i -q
   fi
-done 9< <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_INFRASTRUCTURE_TERRAFORM_DIR")" workspace list)
+done 9< <("$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace list" -i -q)

--- a/bin/deploy/list-accounts
+++ b/bin/deploy/list-accounts
@@ -12,4 +12,4 @@ do
   then
     echo "$workspace"
   fi
-done < <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)
+done < <("$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace list" -a -q)

--- a/bin/deploy/list-infrastructures
+++ b/bin/deploy/list-infrastructures
@@ -12,4 +12,4 @@ do
   then
     echo "$workspace"
   fi
-done < <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_INFRASTRUCTURE_TERRAFORM_DIR")" workspace list)
+done < <("$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace list" -i -q)

--- a/bin/terraform-dependencies/get-tfvars
+++ b/bin/terraform-dependencies/get-tfvars
@@ -148,6 +148,6 @@ do
         '. += { "\($workspace_name)": { "path": $workspace_tfvars_path, "key": $workspace_tfvars_file } }')
     fi
   fi
-done 9< <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)
+done 9< <("$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace list" -a -q)
 
 echo "$TFVARS_PATHS_JSON" > "$CONFIG_TFVARS_PATHS_FILE"

--- a/bin/terraform-dependencies/initialise
+++ b/bin/terraform-dependencies/initialise
@@ -38,5 +38,5 @@ while getopts "ruh" opt; do
 done
 
 echo "==> Attempting Terraform init ..."
-terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" init "${ACCOUNT_BOOTSTRAP_OPTIONS[@]}"
-terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_INFRASTRUCTURE_TERRAFORM_DIR")" init "${INFRASTRUCTURE_OPTIONS[@]}"
+"$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "init" -a -q
+"$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "init" -i -q

--- a/bin/terraform-dependencies/set-tfvars
+++ b/bin/terraform-dependencies/set-tfvars
@@ -48,7 +48,7 @@ then
       WORKSPACES+=("$workspace")
       echo "$WORKSPACE_INDEX) $workspace"
     fi
-  done < <(terraform -chdir="$(grealpath --relative-to="$PWD" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR")" workspace list)
+  done < <("$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace list" -a -q)
 
   while true
   do


### PR DESCRIPTION
* The `run-terraform-command` command adds the required terraform parameters, such as `chdir` and `-var-file` when needed. Using this command throughout reduces code duplication