### PR TITLE
Output `AWS_*` and `TF_*` environment variables in `run-terraform-com…

### DIFF
--- a/bin/terraform-dependencies/run-terraform-command
+++ b/bin/terraform-dependencies/run-terraform-command
@@ -114,6 +114,8 @@ if [ "$QUIET_MODE" == 0 ]
 then
   echo "==> Running command:"
   echo "terraform -chdir=$(grealpath --relative-to="$PWD" "$RUN_DIR")"
+  env | { grep "^AWS_" || true; }
+  env | { grep  "^TF_" || true; }
   echo "${OPTIONS[@]}" | sed "s/ / \\\ \n/g" | sed "s/^/  /g"
   echo ""
 fi


### PR DESCRIPTION
…mand` script

* It's useful to know which of these environment variables have been set when running the terraform command. eg. some of the terraform variables are set as environment variables, as well as the `AWS_PROFILE` and `AWS_CONFIG_FILE` variables