### PR TITLE
Fix terraform-run-command command check

### DIFF
--- a/bin/deploy/account-bootstrap
+++ b/bin/deploy/account-bootstrap
@@ -82,7 +82,8 @@ do
   then
     WORKSPACE_EXISTS=1
     "$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace select $workspace" -a -q
-    "$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "${OPTIONS[@]}" -a -q
+    STRING_OPTIONS="${OPTIONS[*]}"
+    "$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "$STRING_OPTIONS" -a -q
   fi
 done 9< <("$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace list" -a -q)
 

--- a/bin/terraform-dependencies/run-terraform-command
+++ b/bin/terraform-dependencies/run-terraform-command
@@ -74,7 +74,7 @@ CHECK_COMMANDS=(
   "console"
 )
 if [[
-  "${CHECK_COMMANDS[*]}" =~ ${OPTIONS[0]} &&
+  "${CHECK_COMMANDS[*]}" =~ $(echo "${OPTIONS[0]}" | cut -d' ' -f1 ) &&
   -n "$CURRENT_WORKSPACE" &&
   "$CURRENT_WORKSPACE" != "default"
 ]]


### PR DESCRIPTION
* `${OPTIONS[@]}` needs to be specifically set to a string as a new variable before being passed to terraform-run-command, otherwise if there is more than one option, it will be passed as a parameter for the script itself
* `${OPTIONS[0]}` will be the full command passed through, but we only want to check the first word