### PR TITLE
Run aws-sso login when credentials have expired

### DIFF
--- a/bin/aws-sso/login
+++ b/bin/aws-sso/login
@@ -30,7 +30,6 @@ while getopts "p:fh" opt; do
   esac
 done
 
-echo "==> Checking AWS SSO registration expiry ..."
 START_URL="$(aws configure get sso_start_url --profile dalmatian-login)"
 AWS_SSO_CACHE_JSON="$(grep -h -e "$START_URL" ~/.aws/sso/cache/*.json || true)"
 EXPIRES_AT="$(echo "$AWS_SSO_CACHE_JSON" | jq -r '.expiresAt')"
@@ -45,6 +44,9 @@ if [[
   "$FORCE_RELOG" == "1"
   ]]
 then
-  echo "==> Attempting AWS SSO login ..."
+  if [ "$QUIET_MODE" == 0 ]
+  then
+    echo "==> Attempting AWS SSO login ..."
+  fi
   aws sso login --profile "$AWS_SSO_PROFILE"
 fi

--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -164,6 +164,14 @@ then
   export AWS_CONFIG_FILE="$CONFIG_AWS_SSO_FILE"
   export AWS_PROFILE="dalmatian-main"
 
+  if [[
+    "$SUBCOMMAND" != "setup" &&
+    ( "$SUBCOMMAND" != "aws-sso" && "$COMMAND" != "login" )
+  ]]
+  then
+    "$APP_ROOT/bin/dalmatian" aws-sso login
+  fi
+
   if [[ -f "$APP_ROOT/bin/configure-commands/$SUBCOMMAND" ]]
   then
     COMMAND_ARGS=( "${@:2}" )


### PR DESCRIPTION
* Some of the commands can throw odd errors if the credentials have expired.
* This will check the credentials everytime a dalmatian command is ran (except for the login command itself, and when running setup).
* This also removes the 'Checking...' message, as it causes too much unnecessary output