### PR TITLE
Fix `deploy infrastructure` workspace selection

### DIFF
--- a/bin/deploy/infrastructure
+++ b/bin/deploy/infrastructure
@@ -182,7 +182,8 @@ do
     -z "$ENVIRONMENT_NAME" ) &&
     "$workspace" != "default" &&
     -n "$workspace" ) ||
-    "$WORKSPACE_NAME" == "$workspace"
+    ( "$WORKSPACE_NAME" == "$workspace" &&
+    -n "$WORKSPACE_NAME" )
   ]]
   then
     "$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace select $workspace" -i -q


### PR DESCRIPTION
* Ensures it wont attempt to select a workspace with an empty name when `-W` isn't specified