### PR TITLE
Add `log_info` bash function

### DIFF
--- a/lib/bash-functions.sh
+++ b/lib/bash-functions.sh
@@ -40,6 +40,34 @@ function err {
   echo "[!] Error: $*" >&2
 }
 
+# Set up a handy log output function
+#
+# @usage log_info -l 'Something happened :)'"
+# @param -l <log>  Any information to output
+# @param -q <0/1>  Quiet mode
+function log_info {
+  OPTIND=1
+  QUIET_MODE=0
+  while getopts "l:q:" opt; do
+    case $opt in
+      l)
+        LOG="$OPTARG"
+        ;;
+      q)
+        QUIET_MODE="$OPTARG"
+        ;;
+      *)
+        echo "Invalid \`log_info\` function usage" >&2
+        exit 1
+        ;;
+    esac
+  done
+  if [ "$QUIET_MODE" == "0" ]
+  then
+    echo "==> $LOG"
+  fi
+}
+
 # Check to see if a binary is installed on the system
 #
 # @usage  is_installed "oathtool"


### PR DESCRIPTION
* Adds a function to output logs in a standard format.
* `-q` can be used to supress the output, allowing a common variable (eg. QUIET_MODE) to be used, rather than using `if` everywhere to check for verbose-ness.
* eg. `log_info "Something happened :)" -q "$QUIET_MODE"`