### PR TITLE
Fix quiet mode for configure commands

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -180,6 +180,16 @@ then
   if [[ -f "$APP_ROOT/bin/configure-commands/$SUBCOMMAND" ]]
   then
     COMMAND_ARGS=( "${@:2}" )
+    QUIET_MODE=0
+    for i in "${!COMMAND_ARGS[@]}"
+    do
+      if [ "${COMMAND_ARGS[i]}" == "-q" ]
+      then
+        QUIET_MODE=1
+        unset "COMMAND_ARGS[i]"
+      fi
+    done
+    export QUIET_MODE
     "$APP_ROOT/bin/configure-commands/$SUBCOMMAND" "${COMMAND_ARGS[@]}"
     exit 0
   fi


### PR DESCRIPTION
* The 'configure-commands' checks if the subcommand (eg `setup`/`login`) exists within the `bin/configure-commands` directory, and sets the remaining args (`${@:2}` rather than `${@:3}`) to be passed to the script. This means `-q` is passed through, even though it was previously unset.
* This adds in the same code to the confgure commands section to ensure it's removed