### PR TITLE
Don't attempt `aws-sso login` when `aws-sso generate-config` is ran

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -184,7 +184,7 @@ then
 
   if [[
     "$SUBCOMMAND" != "setup" &&
-    ( "$SUBCOMMAND" != "aws-sso" && "$COMMAND" != "login" )
+    ( "$SUBCOMMAND" != "aws-sso" && "$COMMAND" != "login" && "$COMMAND" != "generate-config" )
   ]]
   then
     "$APP_ROOT/bin/dalmatian" aws-sso login


### PR DESCRIPTION
* This script generates the config that `aws-sso login` needs. The script itself will run the login once the configuration is in place.