### PR TITLE
Fix bash function file source files

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -31,11 +31,11 @@ do
     continue
   fi
   # shellcheck source=/dev/null
-  source "$BASH_FUNCTION_DIR/$bash_function_file"
+  source "$bash_function_file"
   while IFS='' read -r function_name
   do
     export -f "${function_name?}"
-  done < <(grep "^function" "$BASH_FUNCTION_DIR/$bash_function_file" | cut -d" " -f2)
+  done < <(grep "^function" "$bash_function_file" | cut -d" " -f2)
 done
 
 if [ "${1:0:1}" == "-" ]

--- a/bin/setup
+++ b/bin/setup
@@ -12,7 +12,7 @@ do
     continue
   fi
   # shellcheck source=/dev/null
-  source "$APP_ROOT/lib/bash-functions/$bash_function_file"
+  source "$bash_function_file"
 done
 
 # Check to see if Homebrew is installed, and prompt to install it if it isn't


### PR DESCRIPTION
* The `$bash_function_file` is the full path to the bash function file, so doesn't need the directory prefix