### PR TITLE
Bypass `key-age` check in `login` script

### DIFF
--- a/bin/configure-commands/login
+++ b/bin/configure-commands/login
@@ -66,11 +66,11 @@ echo "  User ID: $USER_ID"
 echo "  Account: $ACCOUNT_ID"
 echo "  Arn:     $USER_ARN"
 
-echo "==> Checking access key age"
-if ! "$APP_ROOT/bin/aws/key-age"
-then
-  exit 1
-fi
+#echo "==> Checking access key age"
+#if ! "$APP_ROOT/bin/aws/key-age"
+#then
+#  exit 1
+#fi
 
 echo "==> Saving configuration settings in $DALMATIAN_CONFIG_FILE ..."
 


### PR DESCRIPTION
* The dalmatian-admin user accounts do not have the `iam:ListAccessKeys` permission, until they are authenticated with MFA.
* This is a temporary bypass (commented out) until we find a fix, as to not block people from using `dalmatian login`