### PR TITLE
Check for new dalmatian release

### DIFF
--- a/bin/configure-commands/update
+++ b/bin/configure-commands/update
@@ -11,7 +11,13 @@ usage() {
   exit 1
 }
 
-GIT_AUTH_TOKEN=""
+log_info -l "Updating dalmatian requires elevated permissions"
+log_info -l "Attempting sudo ..."
+sudo -v
+log_info -l "Elevated permissions are available, continuing ..."
+
+GIT_AUTH_TOKEN="$(jq -r '.dalmatian_update_github_token' < "$CONFIG_SETUP_JSON_FILE")"
+
 while getopts "g:h" opt; do
   case $opt in
     g)
@@ -39,6 +45,11 @@ GITHUB_MESSAGE=$(echo "$RELEASE_JSON" | jq -r '.message')
 if [ "$GITHUB_MESSAGE" != "null" ]
 then
   err "Github: $GITHUB_MESSAGE"
+  log_info -l "This error may have occured, because the dxw/dalmatian-tools repo is private."
+  log_info -l "To use a GitHub token, manually add \`dalmatian_update_github_token\` to the"
+  log_info -l "setup file: $CONFIG_SETUP_JSON_FILE"
+  log_info -l "Note: Redact your GitHub token before sharing this setup file with anyone"
+  log_info -l "This is only a temporary measure whilst the repo is private"
   exit 1
 fi
 
@@ -49,8 +60,13 @@ if [ "$LATEST_REMOTE_TAG" != "$CURRENT_LOCAL_TAG" ]
 then
   if [ -n "$LOCAL_CHANGES" ]
   then
-    err "There is a newer version of $GIT_DALMATIAN_TOOLS_OWNER/$GIT_DALMATIAN_TOOLS_REPO ($CURRENT_LOCAL_TAG -> $LATEST_REMOTE_TAG) but cant update! You have local changes in $APP_ROOT"
-    exit 1
+    err "There may be a newer version of $GIT_DALMATIAN_TOOLS_OWNER/$GIT_DALMATIAN_TOOLS_REPO ($CURRENT_LOCAL_TAG -> $LATEST_REMOTE_TAG) but cant update!"
+    err "This is because you have local changes in $APP_ROOT"
+    if ! yes_no "Do you want to continue without updating? (Y/N)" "N" 
+    then
+      exit 1
+    fi
+    exit 0
   fi
   log_info -l "Updating ..." -q "$QUIET_MODE"
   git -C "$APP_ROOT" checkout main

--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -20,6 +20,12 @@ then
  usage
 fi
 
+IS_PARENT_SCRIPT=0
+if [ "$(ps -o stat= -p $PPID | tr -d ' ')" == "S" ]
+then
+  IS_PARENT_SCRIPT=1
+fi
+
 APP_ROOT="$( cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd -P)"
 export APP_ROOT
 
@@ -190,6 +196,14 @@ then
 
   export AWS_CONFIG_FILE="$CONFIG_AWS_SSO_FILE"
   export AWS_PROFILE="dalmatian-main"
+
+  if [ "$SUBCOMMAND" != "update" ]
+  then
+    if [ "$IS_PARENT_SCRIPT" == 1 ]
+    then
+      "$APP_ROOT/bin/dalmatian" update -q
+    fi
+  fi
 
   if [[
     "$SUBCOMMAND" != "setup" &&


### PR DESCRIPTION
* This runs the dalmatian update script everytime dalmatian is ran, to ensure that the latest version of Dalmatian is being used. The update script is only ran during the initial call, not when being called by itself (eg. not when dalmatian commands are used within the scripts). It checks for the parent script by checking the process state.
* Because the script will be ran automatically, there is a chance it could break when it gets to running `brew bundle`, because `session-manager-plugin` requires root privileges to install. To mitigate this, there is now a check before any part of the update runs to ensure the user can gain elevated permissions.
* The update script now allows having the git token stored in the setup.json for ease (Until the repo has been made public)