### PR TITLE
Use AWS time when comparing AWS timestamps

### DIFF
--- a/bin/aws-sso/login
+++ b/bin/aws-sso/login
@@ -36,7 +36,7 @@ EXPIRES_AT="$(echo "$AWS_SSO_CACHE_JSON" | jq -r '.expiresAt')"
 if [ -n "$EXPIRES_AT" ]
 then
   EXPIRES_AT_SEC="$(TZ="UTC" date -j -f "%Y-%m-%dT%H:%M:%SZ" "+%s" "$EXPIRES_AT")"
-  EPOCH="$(date +%s)"
+  EPOCH="$(aws_epoch)"
 fi
 if [[
   "$EPOCH" -gt "$EXPIRES_AT_SEC" ||

--- a/lib/bash-functions/aws_epoch.sh
+++ b/lib/bash-functions/aws_epoch.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Returns the epoch in seconds from AWS NTP.
+# This should be the most reliable current timestamp when comparing timestamps
+# from AWS resources, rather than using the date/time from a local machine.
+#
+# @usage aws_epoch
+function aws_epoch {
+  AWS_NTP_SERVER="0.amazon.pool.ntp.org"
+
+  NTP_STRING="$(sntp "$AWS_NTP_SERVER" | tail -n1)"
+  AWS_DATE="$(echo "$NTP_STRING" | cut -d ' ' -f 1)"
+  AWS_TIME="$(echo "$NTP_STRING" | cut -d ' ' -f 2 | cut -d '.' -f 1)"
+  AWS_TZ="$(echo "$NTP_STRING" | cut -d ' ' -f 3)"
+
+  AWS_EPOCH="$(date -j -f "%Y-%m-%d %T (%z)" "+%s" "$AWS_DATE $AWS_TIME $AWS_TZ")"
+  echo "$AWS_EPOCH"
+}


### PR DESCRIPTION
* When comparing timestamps from AWS, we should use the time from the AWS NTP servers, as this is more likely to be the source of the timestamps used within AWS - Rather than using the local time which can differ on different machines.