### PR TITLE
FIX Aurora SQL backup download script

### DIFF
--- a/bin/aurora/download-sql-backup
+++ b/bin/aurora/download-sql-backup
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# Redirect command
-COMMAND_ARGS=( "${@:2}" )
-"$APP_ROOT/bin/dalmatian" rds download-sql-backup "${COMMAND_ARGS[@]}"
+# Redirect command. Pass on all arguments except "aurora download-sql-backup"
+"$APP_ROOT/bin/dalmatian" rds download-sql-backup "${@:1}"
 exit 0


### PR DESCRIPTION
Before some CLI arguments were not being passed to the rds/download-backup-script. Now, we pass on all arguments except "aurora download-backup-script".

## Testing

Test with something like:

```shell
dalmatian aurora download-sql-backup -i judiciary-int -r intranet -e staging
```