### PR TITLE
Use Bash lib functions consistently in rename-env-var script

### DIFF
--- a/bin/service/rename-environment-variable
+++ b/bin/service/rename-environment-variable
@@ -22,8 +22,7 @@ usage() {
 # if there are no arguments passed exit with usage
 if [ $# -lt 1 ]
 then
-  echo "ERROR: No arguments passed"
-  echo
+  err "No arguments passed"
   usage 1
 fi
 
@@ -59,8 +58,7 @@ if [[
   || -z "$ENVIRONMENT"
 ]]
 then
-  echo "ERROR: Missing -i, -e or -s parameters"
-  echo
+  err "Missing -i, -e or -s parameters"
   usage 1
 fi
 
@@ -68,8 +66,7 @@ if [[
   ( -z "$KEY" || -z "$NEW_KEY" )
 ]]
 then
-  echo "ERROR: Missing -k or -n parameters"
-  echo
+  err "Missing -k or -n parameters"
   usage 1
 fi
 


### PR DESCRIPTION
To test, write some nonsense:

```shell
❯ dalmatian service rename-environment-variable
[!] Error: No arguments passed
Usage: rename-environment-variable [OPTIONS]
This command can rename environment variables for a service
  -h                     - help
  -i <infrastructure>    - infrastructure name
  -s <service>           - service name
  -e <environment>       - environment name (e.g. 'staging' or 'prod')
  -k <key>               - key e.g SMTP_HOST
  -n <new-key>           - new key e.g. SMTP_PORT
```

You should get an error message before the usage text and the exit code of the command should be non-zero.
