### PR TITLE
Add list of exposed ports

### DIFF
--- a/bin/util/ip-port-exposed
+++ b/bin/util/ip-port-exposed
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -eq 0 ]
+then
+ usage
+fi
+
+while getopts "i:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+]]
+then
+  usage
+fi
+
+echo "Searching ..."
+
+PORTS_FILE="/tmp/$(date +%s).exposed_ports.txt"
+
+aws ec2 describe-security-groups \
+  --query "SecurityGroups[*].[GroupId, GroupName, IpPermissions[?IpRanges[?CidrIp == '0.0.0.0/0']].{FromPort:FromPort, ToPort:ToPort, IpRanges:IpRanges[*].CidrIp}]" \
+  --output json | jq -r '.[] | "\(.[0]) \(.[1]) \(.[2][].FromPort) \(.[2][].ToPort) \(.[2][].IpRanges | join(", "))"' > "$PORTS_FILE"
+
+if grep -E -v "80|443" < "$PORTS_FILE" ; then
+  echo "Exposed port found!"
+else
+  echo "No exposed ports found!"
+fi
+
+echo "Finished!"


### PR DESCRIPTION
From a security stance we should have the ability to find out which ports are opened to the world across our AWS accounts.