### PR TITLE
Prevent local AWS environment variables superceding Dalmatian profile

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -197,6 +197,17 @@ then
   export AWS_CONFIG_FILE="$CONFIG_AWS_SSO_FILE"
   export AWS_PROFILE="dalmatian-main"
 
+  # These AWS environment variables take precedence when authenticating, which
+  # can cause errors if they are not related to Dalmatian
+  unset AWS_SESSION_TOKEN
+  unset AWS_SECRET_ACCESS_KEY
+  unset AWS_ACCESS_KEY_ID
+  unset AWS_DEFAULT_REGION
+  unset AWS_DEFAULT_OUTPUT
+  unset AWS_REGION
+  unset AWS_ROLE_ARN
+  unset AWS_ROLE_SESSION_NAME
+
   if [ "$SUBCOMMAND" != "update" ]
   then
     if [ "$IS_PARENT_SCRIPT" == 1 ]


### PR DESCRIPTION
* If a local envionment has `AWS_` environment variables set, that manage authentication, they will be used before the configuration set in the `AWS_PROFILE` that Dalmatian manages.
* `unset`ing these environment variables will ensure the configuration in the AWS profile will be used. Note that it doesn't remove them from the local environment, only for the Dalmatian process