### PR TITLE
Fix dalmatian setup requiring dalmatian aws-sso login

### DIFF
--- a/bin/configure-commands/update
+++ b/bin/configure-commands/update
@@ -8,19 +8,24 @@ usage() {
   echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
   echo "  -g <git_auth_token>    - Git Auth token (Optional - only required if dalmatian tools repo is private)"
   echo "  -f <force_update>      - Force update (Runs through the upate process even if dalmatian-tools is on the latest version)"
+  echo "  -U <unauthenticated>   - Runs the update process, without running commands that require intial Dalmatian setup"
   echo "  -h                     - help"
   exit 1
 }
 
 GIT_AUTH_TOKEN="$(jq -r '.dalmatian_update_github_token' < "$CONFIG_SETUP_JSON_FILE")"
 FORCE_UPDATE=0
-while getopts "g:fh" opt; do
+UNAUTHENTICATED=0
+while getopts "g:fUh" opt; do
   case $opt in
     g)
       GIT_AUTH_TOKEN=$OPTARG
       ;;
     f)
       FORCE_UPDATE=1
+      ;;
+    U)
+      UNAUTHENTICATED=1
       ;;
     h)
       usage
@@ -80,8 +85,11 @@ then
   git -C "$APP_ROOT" -c advice.detachedHead=false checkout "$LATEST_REMOTE_TAG"
   log_info -l "Updating brew packages ..." -q "$QUIET_MODE"
   brew bundle --file="$APP_ROOT/Brewfile"
-  "$APP_ROOT/bin/dalmatian" terraform-dependencies clone -I
-  "$APP_ROOT/bin/dalmatian" terraform-dependencies get-tfvars
+  if [ "$UNAUTHENTICATED" == 0 ]
+  then
+    "$APP_ROOT/bin/dalmatian" terraform-dependencies clone -I
+    "$APP_ROOT/bin/dalmatian" terraform-dependencies get-tfvars
+  fi
 else
   log_info -l "You are on the latest version ($LATEST_REMOTE_TAG) 👍" -q "$QUIET_MODE"
 fi

--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -212,13 +212,19 @@ then
   then
     if [ "$IS_PARENT_SCRIPT" == 1 ]
     then
-      "$APP_ROOT/bin/dalmatian" update -q
+      if [ "$SUBCOMMAND" == "setup" ]
+      then
+        "$APP_ROOT/bin/dalmatian" update -q -U
+      else
+        "$APP_ROOT/bin/dalmatian" update -q
+      fi
     fi
   fi
 
   if [[
     "$SUBCOMMAND" != "setup" &&
-    ( "$SUBCOMMAND" != "aws-sso" && "$COMMAND" != "login" && "$COMMAND" != "generate-config" )
+    ( "$SUBCOMMAND" != "aws-sso" && "$COMMAND" != "login" && "$COMMAND" != "generate-config" ) &&
+    "$SUBCOMMAND" != "update"
   ]]
   then
     "$APP_ROOT/bin/dalmatian" aws-sso login


### PR DESCRIPTION
* The `dalmatian aws-sso login` command is ran when running an update. The update is ran everytime `dalmatian` is ran. This prevents `dalmatian setup` being ran.
* This fix ensures that the login wont be attempted whilst running dalmatian setup, until it is able to