### PR TITLE
Fix setup move `clone` to `generate-config`

### DIFF
--- a/bin/aws-sso/generate-config
+++ b/bin/aws-sso/generate-config
@@ -34,6 +34,8 @@ echo ""
 
 "$APP_ROOT/bin/dalmatian" aws-sso login -p dalmatian-login
 
+"$APP_ROOT/bin/dalmatian" terraform-dependencies clone
+
 "$APP_ROOT/bin/dalmatian" terraform-dependencies initialise
 
 while IFS='' read -r workspace

--- a/bin/configure-commands/setup
+++ b/bin/configure-commands/setup
@@ -134,8 +134,6 @@ echo "--- Dalmatian account configuration ---"
 MAIN_DALMATIAN_ACCOUNT_ID=$(read_prompt_with_setup_default -p "Main dalmatian account ID" -d "main_dalmatian_account_id")
 echo ""
 
-"$APP_ROOT/bin/dalmatian" terraform-dependencies clone
-
 "$APP_ROOT/bin/dalmatian" aws-sso generate-config
 
 "$APP_ROOT/bin/dalmatian" aws-sso account-init -i "$MAIN_DALMATIAN_ACCOUNT_ID" -r "$DEFAULT_REGION" -n "dalmatian-main"


### PR DESCRIPTION
* This ensures a dalmatian command isn't ran in setup until it has generated the config for `dalmatian-login`