### PR TITLE
Add update check

### DIFF
--- a/bin/configure-commands/update
+++ b/bin/configure-commands/update
@@ -26,6 +26,21 @@ while getopts "fh" opt; do
   esac
 done
 
+CONFIG_UPDATE_CHECK_JSON_FILE="$CONFIG_DIR/update-check.json"
+if [ ! -f "$CONFIG_UPDATE_CHECK_JSON_FILE" ]
+then
+  UPDATE_CHECK_JSON=$(
+    jq -n \
+      --arg complete_status "1" \
+      '{
+        complete_status: $complete_status
+      }'
+  )
+  echo "$UPDATE_CHECK_JSON" > "$CONFIG_UPDATE_CHECK_JSON_FILE"
+fi
+
+UPDATE_CHECK_LAST_COMPLETE_STATUS=$(jq -r '.complete_status' < "$CONFIG_UPDATE_CHECK_JSON_FILE")
+
 log_info -l "Checking for newer version ..." -q "$QUIET_MODE"
 RELEASE_JSON=$(curl -s "$GIT_DALMATIAN_TOOLS_API_REPOS_LATEST_RELEASE_URL" | jq -r)
 
@@ -47,9 +62,20 @@ CURRENT_LOCAL_TAG=$(git -C "$APP_ROOT" describe --tags)
 LOCAL_CHANGES=$(git -C "$APP_ROOT" status --porcelain)
 if [[
   "$LATEST_REMOTE_TAG" != "$CURRENT_LOCAL_TAG" ||
-  "$FORCE_UPDATE" == 1
+  "$FORCE_UPDATE" == 1 ||
+  "$UPDATE_CHECK_LAST_COMPLETE_STATUS" == 0
 ]]
 then
+  if [ "$UPDATE_CHECK_LAST_COMPLETE_STATUS" == 0 ]
+  then
+    err "The last update did not complete successfully. Attempting another update ..."
+  fi
+  UPDATE_CHECK_JSON=$(
+    jq -r \
+      --arg complete_status "0" \
+      < "$CONFIG_UPDATE_CHECK_JSON_FILE"
+  )
+  echo "$UPDATE_CHECK_JSON" > "$CONFIG_UPDATE_CHECK_JSON_FILE"
   if [ -n "$LOCAL_CHANGES" ]
   then
     err "There may be a newer version of $GIT_DALMATIAN_TOOLS_OWNER/$GIT_DALMATIAN_TOOLS_REPO ($CURRENT_LOCAL_TAG -> $LATEST_REMOTE_TAG) but cant update!"
@@ -72,6 +98,13 @@ then
   brew bundle --file="$APP_ROOT/Brewfile"
   "$APP_ROOT/bin/dalmatian" terraform-dependencies clone -I
   "$APP_ROOT/bin/dalmatian" terraform-dependencies get-tfvars
+  UPDATE_CHECK_JSON=$(
+    jq -r \
+      '.complete_status |= "1"' \
+      < "$CONFIG_UPDATE_CHECK_JSON_FILE"
+  )
+  echo "$UPDATE_CHECK_JSON" > "$CONFIG_UPDATE_CHECK_JSON_FILE"
+  log_info -l "Update complete 👍" -q "$QUIET_MODE"
 else
   log_info -l "You are on the latest version ($LATEST_REMOTE_TAG) 👍" -q "$QUIET_MODE"
 fi

--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -166,6 +166,7 @@ if [[
 then
   export CONFIG_DIR="$HOME/.config/dalmatian"
   export CONFIG_SETUP_JSON_FILE="$CONFIG_DIR/setup.json"
+  export CONFIG_UPDATE_CHECK_JSON_FILE="$CONFIG_DIR/update-check.json"
   export CONFIG_CACHE_DIR="$CONFIG_DIR/.cache"
   export CONFIG_AWS_SSO_FILE="$CONFIG_DIR/dalmatian-sso.config"
   export CONFIG_ACCOUNT_BOOTSTRAP_BACKEND_VARS_FILE="$CONFIG_DIR/account-bootstrap-backend.vars"


### PR DESCRIPTION
* If an update fails for whatever reason, it can cause issues using dalmatian-tools. This adds an update check, to ensure an update has comepleted successfully before attempting to run any commands.
* An `update-check.json` file is stored in the `.config/dalmatian` directory, which contains a `complete_status`. When an update is started, this is set to 0, and then set to 1 when it completes.