### PR TITLE
Fix update check initial value

### DIFF
--- a/bin/configure-commands/update
+++ b/bin/configure-commands/update
@@ -72,7 +72,7 @@ then
   fi
   UPDATE_CHECK_JSON=$(
     jq -r \
-      --arg complete_status "0" \
+      '.complete_status |= 0' \
       < "$CONFIG_UPDATE_CHECK_JSON_FILE"
   )
   echo "$UPDATE_CHECK_JSON" > "$CONFIG_UPDATE_CHECK_JSON_FILE"


### PR DESCRIPTION
* Fixed the `UPDATE_CHECK_JSON` jq so that it actually sets the `complete_status` to 0 at the beginning of the update