### PR TITLE
Ensure tfenv is used

### DIFF
--- a/bin/configure-commands/update
+++ b/bin/configure-commands/update
@@ -96,6 +96,8 @@ then
   git -C "$APP_ROOT" -c advice.detachedHead=false checkout "$LATEST_REMOTE_TAG"
   log_info -l "Updating brew packages ..." -q "$QUIET_MODE"
   brew bundle --file="$APP_ROOT/Brewfile"
+  log_info -l "Ensuring tfenv is configured ..."
+  brew link --overwrite tfenv
   "$APP_ROOT/bin/dalmatian" terraform-dependencies clone -I
   "$APP_ROOT/bin/dalmatian" terraform-dependencies get-tfvars
   UPDATE_CHECK_JSON=$(

--- a/bin/setup
+++ b/bin/setup
@@ -33,6 +33,7 @@ fi
 # Install or update the brew taps/casks in the Brewfile
 BREW_BIN=$(command -v "brew")
 $BREW_BIN bundle install
+$BREW_BIN link --overwrite tfenv
 
 # Test if the user is on an Intel or Apple Silicon mac
 IS_APPLE_SILICON=0 # false


### PR DESCRIPTION
* Sometimes terraform will be linked rather than tfenv in homebrew, which causes the `.terraform-version` files to not be respected.
* This forces a brew link for tfenv