### PR TITLE
Fix SSO Start URL cache search

### DIFF
--- a/bin/aws-sso/login
+++ b/bin/aws-sso/login
@@ -31,7 +31,7 @@ while getopts "p:fh" opt; do
 done
 
 START_URL="$(aws configure get sso_start_url --profile dalmatian-login)"
-AWS_SSO_CACHE_JSON="$(grep -h -e "$START_URL" ~/.aws/sso/cache/*.json || true)"
+AWS_SSO_CACHE_JSON="$(grep -h -e "\"$START_URL\"" ~/.aws/sso/cache/*.json || true)"
 EXPIRES_AT="$(echo "$AWS_SSO_CACHE_JSON" | jq -r '.expiresAt')"
 if [ -n "$EXPIRES_AT" ]
 then


### PR DESCRIPTION
* To get the expiration of an SSO token, a grep is used to search the json files in `~/.aws/sso/cache`. However the grep can return multiple results if aws-sso has been logged in with simliar urls, which causes the `registrationExpiresAt` unreadable.
* This adds escaped quotes to the grep to ensure only an exact match will be returned