### PR TITLE
Fix: Add region to external account config

### DIFF
--- a/bin/aws-sso/generate-config
+++ b/bin/aws-sso/generate-config
@@ -61,7 +61,8 @@ do
         "$CONFIG_AWS_SSO_FILE" \
         "$SSO_CONFIG_ACCOUNT_NAME" \
         "dalmatian-main" \
-        "$EXTERNAL_ROLE_ARN"
+        "$EXTERNAL_ROLE_ARN" \
+        "$SSO_CONFIG_REGION"
     else
       append_sso_config_file \
         "$CONFIG_AWS_SSO_FILE" \

--- a/lib/bash-functions/append_sso_config_file_assume_role.sh
+++ b/lib/bash-functions/append_sso_config_file_assume_role.sh
@@ -10,11 +10,13 @@ function append_sso_config_file_assume_role {
   profile_name="$2"
   source_profile="$3"
   role_arn="$4"
+  region="$5"
 
   cat <<EOT >> "$config_file"
 [profile $profile_name]
 source_profile = $source_profile
 role_arn = $role_arn
+region = $region
 
 EOT
 }


### PR DESCRIPTION
* The region is required in the aws configuration