### PR TITLE
Fix run-terraform-command post options

### DIFF
--- a/bin/terraform-dependencies/run-terraform-command
+++ b/bin/terraform-dependencies/run-terraform-command
@@ -81,7 +81,11 @@ if [[
 ]]
 then
   FIRST_OPTION=$(echo "${OPTIONS[0]}" | cut -d' ' -f1)
-  POST_OPTIONS=$(echo "${OPTIONS[0]}" | cut -d' ' -f2-)
+  POST_OPTIONS=""
+  if [ "$(echo "${OPTIONS[0]}" | grep -o " " | wc -l | xargs)" != "0" ]
+  then
+    POST_OPTIONS=$(echo "${OPTIONS[0]}" | cut -d' ' -f2-)
+  fi
   OPTIONS=()
   OPTIONS+=("$FIRST_OPTION")
   if [ "$TERRAFORM_PROJECT" == "account-bootstrap" ]


### PR DESCRIPTION
* If the command is a single word, the cut for POST_OPTIONS to get all fields from the second field, will just return the first word.
* This adds a condition to only parse the POST_OPTIONS if there is more than 1 word.