### PR TITLE
Add terraform import commands

### DIFF
--- a/bin/terraform-dependencies/create-import-file
+++ b/bin/terraform-dependencies/create-import-file
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                                  - help"
+  echo "  -o <output-location>                - Absolute path to output the import.tf file"
+  exit 1
+}
+
+while getopts "o:h" opt; do
+  case $opt in
+    o)
+      IMPORT_FILE_OUTPUT_PATH=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [ -z "$IMPORT_FILE_OUTPUT_PATH" ]
+then
+  usage
+fi
+
+if [ -f "$IMPORT_FILE_OUTPUT_PATH" ]
+then
+  err "$IMPORT_FILE_OUTPUT_PATH already exists. Please choose a different location."
+  exit 1
+fi
+
+MESSAGE=$(cat <<EOT
+You will be promted for the target resource reference (\`to\`),
+    and then the input reference (\`id\`)
+    An attempt will be made to display a Terraform Documetation link
+    to the 'Import' section, which explains wether the resource 'id', 'arn'
+    or 'name' is required
+    You can add multiple resources as needed
+    Press CTRL-C once completed, and the file will be saved to the specified
+    location
+EOT
+)
+log_info -l "$MESSAGE" -q "$QUIET_MODE"
+echo ""
+
+while true
+do
+  append_import_block "$IMPORT_FILE_OUTPUT_PATH"
+  echo ""
+done

--- a/bin/terraform-dependencies/link-import-file
+++ b/bin/terraform-dependencies/link-import-file
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                                  - help"
+  echo "  -a <account_bootstrap_import_file>  - Filename of import.tf file to link to the Account Bootstrap module"
+  echo "  -i <infrastructure_import_file>     - Filename of import.tf file to link to the Infrastructure module"
+  exit 1
+}
+
+while getopts "a:i:h" opt; do
+  case $opt in
+    a)
+      ACCOUNT_BOOTSTRAP_IMPORT_FILE=$OPTARG
+      ;;
+    i)
+      INFRASTRUCTURE_IMPORT_FILE=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$ACCOUNT_BOOTSTRAP_IMPORT_FILE" &&
+  -z $INFRASTRUCTURE_IMPORT_FILE
+]]
+then
+  usage
+fi
+
+if [ -n "$ACCOUNT_BOOTSTRAP_IMPORT_FILE" ]
+then
+  if [ -f "$ACCOUNT_BOOTSTRAP_IMPORT_FILE" ]
+  then
+    ln -s "$ACCOUNT_BOOTSTRAP_IMPORT_FILE" "$TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR/dalmatian-import.tf"
+    log_info -l "$ACCOUNT_BOOTSTRAP_IMPORT_FILE linked to $TMP_ACCOUNT_BOOTSTRAP_TERRAFORM_DIR/dalmatian-import.tf" -q "$QUIET_MODE"
+  else
+    err "$ACCOUNT_BOOTSTRAP_IMPORT_FILE is not a file"
+  fi
+fi
+
+if [ -n "$INFRASTRUCTURE_IMPORT_FILE" ]
+then
+  if [ -f "$INFRASTRUCTURE_IMPORT_FILE" ]
+  then
+    ln -s "$INFRASTRUCTURE_IMPORT_FILE" "$TMP_INFRASTRUCTURE_TERRAFORM_DIR/dalmatian-import.tf"
+    log_info -l "$INFRASTRUCTURE_IMPORT_FILE linked to $TMP_INFRASTRUCTURE_TERRAFORM_DIR/dalmatian-import.tf" -q "$QUIET_MODE"
+  else
+    err "$INFRASTRUCTURE_IMPORT_FILE is not a file"
+  fi
+fi

--- a/lib/bash-functions/append_import_block.sh
+++ b/lib/bash-functions/append_import_block.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Dalmatian specific function
+# Appends an import block to the provided
+# terraform configuration file
+function append_import_block {
+  config_file="$1"
+
+  read -rp "to: " TO
+  PROVIDER=$(echo "$TO" | cut -d '_' -f1)
+  RESOURCE=$(echo "$TO" | cut -d '_' -f2- | cut -d '.' -f1)
+  IMPORT_DOC_URL="https://registry.terraform.io/providers/hashicorp/${PROVIDER}/latest/docs/resources/${RESOURCE}#import"
+  echo "Terraform import docs for ${PROVIDER}_${RESOURCE}: $IMPORT_DOC_URL"
+  read -rp "id: " ID
+
+  cat <<EOT >> "$config_file"
+import {
+  to = $TO
+  id = "$ID"
+}
+
+EOT
+}


### PR DESCRIPTION
* This adds 2 commands for `terraform-dependencies - `create-import-file` and `link-import-file`
* `create-import-file` is a helper tool, which can be used to easily create import blocks. Given a resource reference, it will output the Terraform Documentation URL, to the import section, showing wether the 'id' needs to be the 'id', 'arn' or name. Once both `to` and `id` are provided, it will output the import block to the given location.
* `link-import-file` creates a symlink to either the temporary Account Bootstrap or Infrastructure module, allowing the import blocks to be read whilst running dalmatian terraform commands (eg. a deploy)