### PR TITLE
Set EDITOR env

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -198,6 +198,11 @@ then
   export AWS_CONFIG_FILE="$CONFIG_AWS_SSO_FILE"
   export AWS_PROFILE="dalmatian-main"
 
+  if [ -z "$EDITOR" ]
+  then
+    export EDITOR="nano"
+  fi
+
   # These AWS environment variables take precedence when authenticating, which
   # can cause errors if they are not related to Dalmatian
   unset AWS_SESSION_TOKEN


### PR DESCRIPTION
* "$EDITOR" is used to open and edit files, so that a prefered editor can be used
* If it's not set, the scripts fail. This change sets the EDITOR env to "nano" (probably most user friendly) if it is not already set