### PR TITLE
Download later modified tfvars

### DIFF
--- a/bin/terraform-dependencies/v2/get-tfvars
+++ b/bin/terraform-dependencies/v2/get-tfvars
@@ -55,9 +55,23 @@ if [ "$TFVARS_BUCKET_EXISTS" == 1 ]
 then
   echo "==> Downloading tfvars ..."
 
-  if aws s3api head-object --bucket "$TFVARS_BUCKET_NAME" --key "$DEAFULT_TFAVRS_FILE_NAME" > /dev/null 2>&1
+  TFVAR_FILE_META_JSON="$(
+    "$APP_ROOT/bin/dalmatian" aws-sso run-command \
+      -p dalmatian-main \
+      s3api head-object \
+      --bucket "$TFVARS_BUCKET_NAME" \
+      --key "$DEAFULT_TFAVRS_FILE_NAME" \
+      2>/dev/null || true
+  )"
+  if [[ "$TFVAR_FILE_META_JSON" ]]
   then
     if [[ "$NEW_TFVARS_ONLY" == 0 || ! -f "$CONFIG_TFVARS_DIR/$DEAFULT_TFAVRS_FILE_NAME" ]]
+    then
+      aws s3 cp "s3://$TFVARS_BUCKET_NAME/$DEAFULT_TFAVRS_FILE_NAME" "$CONFIG_TFVARS_DIR/."
+    fi
+    TFVAR_FILE_REMOTE_LAST_MODIFIED="$(echo "$TFVAR_FILE_META_JSON" | jq -r '.LastModified' | gdate +%s)"
+    TFVAR_FILE_LOCAL_LAST_MODIFIED="$(gdate -r "$CONFIG_TFVARS_DIR/$DEAFULT_TFAVRS_FILE_NAME" +%s)"
+    if [[ "$TFVAR_FILE_REMOTE_LAST_MODIFIED" -gt "$TFVAR_FILE_LOCAL_LAST_MODIFIED" ]]
     then
       aws s3 cp "s3://$TFVARS_BUCKET_NAME/$DEAFULT_TFAVRS_FILE_NAME" "$CONFIG_TFVARS_DIR/."
     fi
@@ -66,9 +80,23 @@ then
     DEFAULT_TFVARS_EXISTS=0
   fi
 
-  if aws s3api head-object --bucket "$TFVARS_BUCKET_NAME" --key "$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" > /dev/null 2>&1
+  TFVAR_FILE_META_JSON="$(
+    "$APP_ROOT/bin/dalmatian" aws-sso run-command \
+      -p dalmatian-main \
+      s3api head-object \
+      --bucket "$TFVARS_BUCKET_NAME" \
+      --key "$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" \
+      2>/dev/null || true
+  )"
+  if [[ "$TFVAR_FILE_META_JSON" ]]
   then
     if [[ "$NEW_TFVARS_ONLY" == 0 || ! -f "$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" ]]
+    then
+      aws s3 cp "s3://$TFVARS_BUCKET_NAME/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" "$CONFIG_TFVARS_DIR/."
+    fi
+    TFVAR_FILE_REMOTE_LAST_MODIFIED="$(echo "$TFVAR_FILE_META_JSON" | jq -r '.LastModified' | gdate +%s)"
+    TFVAR_FILE_LOCAL_LAST_MODIFIED="$(gdate -r "$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" +%s)"
+    if [[ "$TFVAR_FILE_REMOTE_LAST_MODIFIED" -gt "$TFVAR_FILE_LOCAL_LAST_MODIFIED" ]]
     then
       aws s3 cp "s3://$TFVARS_BUCKET_NAME/$CONFIG_GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE" "$CONFIG_TFVARS_DIR/."
     fi
@@ -77,9 +105,23 @@ then
     GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE_EXISTS=0
   fi
 
-  if aws s3api head-object --bucket "$TFVARS_BUCKET_NAME" --key "$CONFIG_GLOBAL_INFRASTRUCTURE_TFVARS_FILE" > /dev/null 2>&1
+  TFVAR_FILE_META_JSON="$(
+    "$APP_ROOT/bin/dalmatian" aws-sso run-command \
+      -p dalmatian-main \
+      s3api head-object \
+      --bucket "$TFVARS_BUCKET_NAME" \
+      --key "$CONFIG_GLOBAL_INFRASTRUCTURE_TFVARS_FILE" \
+      2>/dev/null || true
+  )"
+  if [[ "$TFVAR_FILE_META_JSON" ]]
   then
     if [[ "$NEW_TFVARS_ONLY" == 0 || ! -f "$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_INFRASTRUCTURE_TFVARS_FILE" ]]
+    then
+      aws s3 cp "s3://$TFVARS_BUCKET_NAME/$CONFIG_GLOBAL_INFRASTRUCTURE_TFVARS_FILE" "$CONFIG_TFVARS_DIR/."
+    fi
+    TFVAR_FILE_REMOTE_LAST_MODIFIED="$(echo "$TFVAR_FILE_META_JSON" | jq -r '.LastModified' | gdate +%s)"
+    TFVAR_FILE_LOCAL_LAST_MODIFIED="$(gdate -r "$CONFIG_TFVARS_DIR/$CONFIG_GLOBAL_INFRASTRUCTURE_TFVARS_FILE" +%s)"
+    if [[ "$TFVAR_FILE_REMOTE_LAST_MODIFIED" -gt "$TFVAR_FILE_LOCAL_LAST_MODIFIED" ]]
     then
       aws s3 cp "s3://$TFVARS_BUCKET_NAME/$CONFIG_GLOBAL_INFRASTRUCTURE_TFVARS_FILE" "$CONFIG_TFVARS_DIR/."
     fi
@@ -137,9 +179,23 @@ do
     WORKSPACE_TFVARS_FILE_EXISTS=0
     if [ "$TFVARS_BUCKET_EXISTS" == 1 ]
     then
-      if aws s3api head-object --bucket "$TFVARS_BUCKET_NAME" --key "$WORKSPACE_TFVARS_FILE" > /dev/null 2>&1
+      TFVAR_FILE_META_JSON="$(
+        "$APP_ROOT/bin/dalmatian" aws-sso run-command \
+          -p dalmatian-main \
+          s3api head-object \
+          --bucket "$TFVARS_BUCKET_NAME" \
+          --key "$CONFIG_GLOBAL_INFRASTRUCTURE_TFVARS_FILE" \
+          2>/dev/null || true
+      )"
+      if [[ "$TFVAR_FILE_META_JSON" ]]
       then
         if [[ "$NEW_TFVARS_ONLY" == 0 || ! -f "$CONFIG_TFVARS_DIR/$WORKSPACE_TFVARS_FILE" ]]
+        then
+          aws s3 cp "s3://$TFVARS_BUCKET_NAME/$WORKSPACE_TFVARS_FILE" "$CONFIG_TFVARS_DIR/."
+        fi
+        TFVAR_FILE_REMOTE_LAST_MODIFIED="$(echo "$TFVAR_FILE_META_JSON" | jq -r '.LastModified' | gdate +%s)"
+        TFVAR_FILE_LOCAL_LAST_MODIFIED="$(gdate -r "$CONFIG_TFVARS_DIR/$WORKSPACE_TFVARS_FILE" +%s)"
+        if [[ "$TFVAR_FILE_REMOTE_LAST_MODIFIED" -gt "$TFVAR_FILE_LOCAL_LAST_MODIFIED" ]]
         then
           aws s3 cp "s3://$TFVARS_BUCKET_NAME/$WORKSPACE_TFVARS_FILE" "$CONFIG_TFVARS_DIR/."
         fi


### PR DESCRIPTION
* When running `terraform-dependencies get-tfvars -n`, to download newer tfvars, it will download tfvars that exist in the remote s3 bucket, but not locally
* This change ensures that it also downloads tfvars from the remote, if the modified date is later than the local file. This ensures that all fires are up to date before running the account bootstrap on the main dalmatian account, which uploads them.