### PR TITLE
Only get new tfvars on update

### DIFF
--- a/bin/configure-commands/v2/update
+++ b/bin/configure-commands/v2/update
@@ -101,7 +101,7 @@ then
   log_info -l "Ensuring tfenv is configured ..."
   brew link --overwrite tfenv
   "$APP_ROOT/bin/dalmatian" terraform-dependencies clone -I
-  "$APP_ROOT/bin/dalmatian" terraform-dependencies get-tfvars
+  "$APP_ROOT/bin/dalmatian" terraform-dependencies get-tfvars -n
   UPDATE_CHECK_JSON=$(
     jq -r \
       '.complete_status |= "1"' \


### PR DESCRIPTION
* Now that the `terraform-dependencies get-tfvars` command correctly updates the tfvars, without overwriting local changes, it will be prefereable to use this option during an update to prevent destroying any local changes someone has made - As an update will run automatically on any command if an update is available.