### PR TITLE
Fix aurora import-dump, ecs file-upload script location

### DIFF
--- a/bin/aurora/v1/import-dump
+++ b/bin/aurora/v1/import-dump
@@ -148,7 +148,7 @@ esac
 
 echo "Uploading $DB_DUMP_FILE ..."
 
-"$APP_ROOT/bin/ecs/file-upload" -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT" -s "$DB_DUMP_FILE" -t "/tmp/$(basename "$DB_DUMP_FILE")" -I "$ECS_INSTANCE_ID"
+"$APP_ROOT/bin/ecs/v1/file-upload" -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT" -s "$DB_DUMP_FILE" -t "/tmp/$(basename "$DB_DUMP_FILE")" -I "$ECS_INSTANCE_ID"
 
 echo "==> Uploading complete!"
 


### PR DESCRIPTION
* The ecs file-upload script now resides in a `v1` directory