### PR TITLE
Add custom script directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,8 @@
 bin/tmp
 tmp
 
+# custom script directory
+bin/custom/v2/*
+!bin/custom/v2/.gitkeep
+
 Brewfile.lock.json


### PR DESCRIPTION
* Its useful sometimes to be able to create custom or personal scripts, that use the dalmatian-tools envars and functions (Rather than trying to only deal with the output from built-in commands).
* Having this directory here, gitignored, allows scripts to be added and then ran with: ``` dalmatian custom my-script ```