### PR TITLE
Configure Renovate to auto update the terraform-project-versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,27 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  {
+    "customManagers": [
+      {
+        "fileMatch": ["^terraform-project-versions\\.json$"],
+        "matchStrings": [
+          "\"terraform-dxw-dalmatian-infrastructure\":\\s*\"(?<currentValue>[^\"]+)\""
+        ],
+        "datasource": "github-releases",
+        "depName": "dxw/terraform-dxw-dalmatian-infrastructure",
+        "versioning": "semver-coerced"
+      },
+      {
+        "fileMatch": ["^terraform-project-versions\\.json$"],
+        "matchStrings": [
+          "\"terraform-dxw-dalmatian-account-bootstrap\":\\s*\"(?<currentValue>[^\"]+)\""
+        ],
+        "datasource": "github-releases",
+        "depName": "dxw/terraform-dxw-dalmatian-account-bootstrap",
+        "versioning": "semver-coerced"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
* Configures 2 custom managers, 1 for each terraform project (terraform-dxw-dalmatian-infrastructure and terraform-dxw-dalmatian-account-bootstrap), to update the version number within terraform-project-versions.json