### PR TITLE
Exit `resolve_profile` if the profile doesn't exist

### DIFF
--- a/lib/bash-functions/resolve_aws_profile.sh
+++ b/lib/bash-functions/resolve_aws_profile.sh
@@ -55,5 +55,20 @@ function resolve_aws_profile {
   fi
   
   PROFILE_NAME="$(echo "$ACCOUNT_WORKSPACE" | cut -d'-' -f5-)"
+  PROFILE_EXISTS=0
+  while IFS='' read -r PROFILE
+  do
+    if [ "$PROFILE_NAME" == "$PROFILE" ]
+    then
+      PROFILE_EXISTS=1
+      break
+    fi
+  done < <(aws configure list-profiles)
+  if [ "$PROFILE_EXISTS" != 1 ]
+  then
+    echo "Error: Profile does not exist for $INFRASTRUCTURE_NAME $ENVIRONMENT_NAME $DALMATIAN_ACCOUNT" >&2
+    echo "Try running \`dalmatian aws-sso generate-config\` first" >&2
+    exit 1
+  fi
   echo "$PROFILE_NAME"
 }


### PR DESCRIPTION
* This can happen if a new infrastructure has been craeted on one machine, and then the second manchine attempts to run a command on that infrastructure, without first having updated the aws profile configuration.
* This catches the issue, displays a useful message (to run `dalmatian aws-sso generate-config`), and exits
* There doesn't seem to be a good place to run this automatically, without having it run when it doesn't need to (Which will make the commands run slower)