### PR TITLE
homebrew sntp binary must be installed before getting the epoch

### DIFF
--- a/lib/bash-functions/aws_epoch.sh
+++ b/lib/bash-functions/aws_epoch.sh
@@ -10,6 +10,14 @@ set -o pipefail
 function aws_epoch {
   AWS_NTP_SERVER="0.amazon.pool.ntp.org"
 
+  # Trap if the user hasn't updated sntp yet
+  if which sntp | grep -qv 'homebrew' > /dev/null
+  then
+    echo "==> Installing missing dependencies..."
+    BREW_BIN=$(command -v "brew")
+    $BREW_BIN bundle install
+  fi
+
   NTP_STRING="$(sntp "$AWS_NTP_SERVER" | tail -n1)"
   AWS_DATE="$(echo "$NTP_STRING" | cut -d ' ' -f 1)"
   AWS_TIME="$(echo "$NTP_STRING" | cut -d ' ' -f 2 | cut -d '.' -f 1)"


### PR DESCRIPTION
- [`ntp` was recently added to the `Brewfile`](https://github.com/dxw/dalmatian-tools/commit/f441f15de15ffc6b91ff552a8ad91eca4c571a96) but if commands are run directly without a prior `dalmatian setup` then this dependency might get missed. So we can check to ensure it's installed correctly before trying to source an epoch from `sntp`