### PR TITLE
Use recommended domain name for NTP

### DIFF
--- a/lib/bash-functions/aws_epoch.sh
+++ b/lib/bash-functions/aws_epoch.sh
@@ -8,7 +8,7 @@ set -o pipefail
 #
 # @usage aws_epoch
 function aws_epoch {
-  AWS_NTP_SERVER="0.amazon.pool.ntp.org"
+  AWS_NTP_SERVER="time.aws.com"
 
   NTP_STRING="$(sntp "$AWS_NTP_SERVER" | tail -n1)"
   AWS_DATE="$(echo "$NTP_STRING" | cut -d ' ' -f 1)"


### PR DESCRIPTION
* AWS would recommend we use this instead of hardcoding a single timeserver https://aws.amazon.com/about-aws/whats-new/2022/11/amazon-time-sync-internet-public-ntp-service/