### PR TITLE
Move success message to end of script

### DIFF
--- a/bin/aws-sso/v2/login
+++ b/bin/aws-sso/v2/login
@@ -59,4 +59,7 @@ then
     exit 1
   fi
   log_info -l "AWS SSO login succeeded" -q "$QUIET_MODE"
+  exit 0
 fi
+
+echo "You're already logged in. Your existing session will expire on $EXPIRES_AT"

--- a/bin/aws-sso/v2/login
+++ b/bin/aws-sso/v2/login
@@ -54,8 +54,8 @@ then
     -z "$EXPIRES_AT"
   ]]
   then
-    err "AWS SSO login failed (session is expired)"
-    err "Please try log out of AWS in your browser to refresh the session"
+    err "Failed to validate your sign-in with AWS SSO. Your session has expired."
+    err "Please try to log out of AWS in your browser to refresh the session, and try again."
     exit 1
   fi
   log_info -l "AWS SSO login succeeded" -q "$QUIET_MODE"


### PR DESCRIPTION
* If a user's SSO session is still valid and they run 'aws-sso login' again, there would be no output. This change ensures there is at least a final confirmation message