### PR TITLE
Use pretty colours for echo functions

### DIFF
--- a/lib/bash-functions/err.sh
+++ b/lib/bash-functions/err.sh
@@ -7,5 +7,8 @@ set -o pipefail
 # @usage err "A problem happened!"
 # @param $* Any information to pass into stderr
 function err {
-  echo "[!] Error: $*" >&2
+  red='\033[0;31m'
+  clear='\033[0m'
+
+  echo -e "${red}[!] Error: ${clear}$*" >&2
 }

--- a/lib/bash-functions/log_info.sh
+++ b/lib/bash-functions/log_info.sh
@@ -8,6 +8,8 @@ set -o pipefail
 # @param -l <log>  Any information to output
 # @param -q <0/1>  Quiet mode
 function log_info {
+  cyan='\033[0;36m'
+  clear='\033[0m'
   OPTIND=1
   QUIET_MODE=0
   while getopts "l:q:" opt; do
@@ -26,6 +28,6 @@ function log_info {
   done
   if [ "$QUIET_MODE" == "0" ]
   then
-    echo "==> $LOG"
+    echo -e "${cyan}==>${clear} $LOG"
   fi
 }

--- a/lib/bash-functions/read_prompt_with_setup_default.sh
+++ b/lib/bash-functions/read_prompt_with_setup_default.sh
@@ -21,7 +21,8 @@ function read_prompt_with_setup_default {
         SILENT=1
         ;;
       *)
-        echo "Invalid usage"
+        echo "Invalid \`read_prompt_with_setup_default\` function usage" >&2
+        exit 1
         ;;
     esac
   done


### PR DESCRIPTION
For the sake of readability I made the `[!] Error:` and `==>` bits of the log outputs coloured.

Also fixed a warning output for one of the bash functions