### PR TITLE
Fix login quiet mode

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -259,7 +259,7 @@ then
     "$SUBCOMMAND" != "update"
   ]]
   then
-    if [ "$IS_PARENT_SCRIPT" == 1 ]
+    if [[ "$IS_PARENT_SCRIPT" == 1 && "$QUIET_MODE" == 0 ]]
     then
       "$APP_ROOT/bin/dalmatian" aws-sso login
     fi


### PR DESCRIPTION
* Ensures that if `-q` is passed to a command, that the top level (parent script) login respects `QUIET_MODE`