### PR TITLE
Enable quiet mode when not running in a terminal

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -43,6 +43,14 @@ then
 fi
 
 QUIET_MODE=0
+
+# set quiet mode if not running in a terminal
+# e.g when piping output to another command or redirecting output to a file
+if [ ! -t 1 ]
+then
+  QUIET_MODE=1
+fi
+
 for i in "${!COMMAND_ARGS[@]}"
 do
   if [ "${COMMAND_ARGS[i]}" == "-q" ]


### PR DESCRIPTION
When piping output to another command or redirecting output to a file we don't
want our script to output any unnecessary information which may break the other
command.

https://stackoverflow.com/questions/911168/how-can-i-detect-if-my-shell-script-is-running-through-a-pipe