### PR TITLE
Add a script to view tfvars files

### DIFF
--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -231,6 +231,10 @@ then
     export EDITOR="nano"
   fi
 
+  if [ -z "$PAGER" ]
+  then
+    export PAGER="less"
+  fi
   # These AWS environment variables take precedence when authenticating, which
   # can cause errors if they are not related to Dalmatian
   unset AWS_SESSION_TOKEN

--- a/bin/terraform-dependencies/v2/view-tfvars
+++ b/bin/terraform-dependencies/v2/view-tfvars
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                          - help"
+  echo "  -a <dalmatian_account>      - Dalmatian Account (Optional)"
+  echo "  -i <infrastructure_account> - Infrastructure account (Optional)"
+  echo "                                Note: If neither is specified, a list of accounts"
+  echo "                                      and infrastructures will be shown for selection"
+  exit 1
+}
+
+PROJECT_NAME="$(jq -r '.project_name' < "$CONFIG_SETUP_JSON_FILE")"
+PROJECT_NAME_HASH="$(echo -n "$PROJECT_NAME" | sha1sum | head -c 6)"
+TFVARS_BUCKET_NAME="$PROJECT_NAME_HASH-tfvars"
+
+while getopts "a:i:h" opt; do
+  case $opt in
+    a)
+      DALMATIAN_ACCOUNT=$OPTARG
+      ;;
+    i)
+      INFRASTRUCTURE_ACCOUNT=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+WORKSPACES=()
+if [[
+  -z "$DALMATIAN_ACCOUNT" &&
+  -z "$INFRASTRUCTURE_ACCOUNT"
+]]
+then
+  echo "1) Account Bootstrap"
+  echo "2) Infrastructure"
+  read -rp "Select project: " PROJECT
+
+  if [ "$PROJECT" == "1" ]
+  then
+    WORKSPACE_LIST_FLAG="-a"
+  elif [ "$PROJECT" == "2" ]
+  then
+    WORKSPACE_LIST_FLAG="-i"
+  else
+    err "Invalid selection. Please enter either 1 or 2 to make your choice"
+    exit 1
+  fi
+
+  WORKSPACE_INDEX=0
+  while IFS='' read -r workspace
+  do
+    workspace=${workspace/\*/ }
+    workspace=$(echo "$workspace" | xargs)
+    if [[
+      "$workspace" != "default" &&
+      -n "$workspace"
+    ]]
+    then
+      WORKSPACE_INDEX=$(( WORKSPACE_INDEX+1 ))
+      WORKSPACES+=("$workspace")
+      echo "$WORKSPACE_INDEX) $workspace"
+    fi
+  done < <("$APP_ROOT/bin/dalmatian" terraform-dependencies run-terraform-command -c "workspace list" "$WORKSPACE_LIST_FLAG" -q)
+
+  while true
+  do
+    read -rp "Select workspace: " ACCOUNT_INDEX
+
+    if [[
+      "$ACCOUNT_INDEX" -eq "$ACCOUNT_INDEX" &&
+      "$ACCOUNT_INDEX" -gt 0 &&
+      "$ACCOUNT_INDEX" -le "$WORKSPACE_INDEX"
+    ]]
+    then
+      break
+    else
+      err "Invalid selection"
+    fi
+  done
+
+  SELECTED_WORKSPACE="${WORKSPACES[((ACCOUNT_INDEX-1))]}"
+fi
+
+if [[
+  "$PROJECT" == "1" ||
+  -n "$DALMATIAN_ACCOUNT"
+]]
+then
+  TFVARS_FILE_NUMBER="100"
+  if [ -z "$SELECTED_WORKSPACE" ]
+  then
+    SELECTED_WORKSPACE="$DALMATIAN_ACCOUNT"
+  fi
+elif [[
+  "$PROJECT" == "2" ||
+  -n "$INFRASTRUCTURE_ACCOUNT"
+]]
+then
+  TFVARS_FILE_NUMBER="200"
+  if [ -z "$SELECTED_WORKSPACE" ]
+  then
+    SELECTED_WORKSPACE="$INFRASTRUCTURE_ACCOUNT"
+  fi
+fi
+
+WORKSPACE_TFVARS_FILE="$TFVARS_FILE_NUMBER-$SELECTED_WORKSPACE.tfvars"
+WORKSPACE_TFVARS_FILE_EXISTS=0
+
+log_info -l "Checking $WORKSPACE_TFVARS_FILE file ..." -q "$QUIET_MODE"
+
+if aws s3api head-object --bucket "$TFVARS_BUCKET_NAME" --key "$WORKSPACE_TFVARS_FILE" > /dev/null 2>&1
+then
+  aws s3 cp "s3://$TFVARS_BUCKET_NAME/$WORKSPACE_TFVARS_FILE" "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" > /dev/null
+  if ! diff "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" "$CONFIG_TFVARS_DIR/$WORKSPACE_TFVARS_FILE" > /dev/null
+  then
+    err "The remote $WORKSPACE_TFVARS_FILE file is different than your local cached copy."
+    err "This is either because the remote copy has been updated, or you have already edited your local copy"
+    log_info -l "What do you want to do?" -q "$QUIET_MODE"
+    echo "1) Edit my local copy"
+    echo "2) Use the remote copy and edit"
+    echo "3) Show the diff"
+    read -rp "?: " DIFF_OPTION
+    if [ "$DIFF_OPTION" == "1" ]
+    then
+      rm "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars"
+    elif [ "$DIFF_OPTION" == "2" ]
+    then
+      mv "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" "$CONFIG_TFVARS_DIR/$WORKSPACE_TFVARS_FILE"
+    elif [ "$DIFF_OPTION" == "3" ]
+    then
+      diff "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars" "$CONFIG_TFVARS_DIR/$WORKSPACE_TFVARS_FILE"
+      rm "$CONFIG_TFVARS_DIR/temp-diff-check.tfvars"
+      exit 0
+    fi
+  fi
+  WORKSPACE_TFVARS_FILE_EXISTS=1
+fi
+
+if [ "$WORKSPACE_TFVARS_FILE_EXISTS" == "0" ]
+then
+  log_info -l "$WORKSPACE_TFVARS_FILE doesn't exist ..." -q "$QUIET_MODE"
+fi
+
+if [ "$WORKSPACE_TFVARS_FILE_EXISTS" == "1" ]
+then
+
+  # Use PAGER if output is a terminal and cat if it's not
+  if [ -t 1 ]
+  then
+    $PAGER "$CONFIG_TFVARS_DIR/$WORKSPACE_TFVARS_FILE"
+  else
+    cat "$CONFIG_TFVARS_DIR/$WORKSPACE_TFVARS_FILE"
+  fi
+fi
+
+log_info -l "$WORKSPACE_TFVARS_FILE viewed!" -q "$QUIET_MODE"
+


### PR DESCRIPTION
This allows users to view tfvars files without triggering the deploy process if they were using set-tfvars instead.