### PR TITLE
Add V2 rds run-command

### DIFF
--- a/bin/rds/v2/run-command
+++ b/bin/rds/v2/run-command
@@ -1,0 +1,194 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -r <rds_name>          - RDS name (as defined in the Dalmatian config)"
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  echo "  -c <command>           - The command to run in the RDS shell"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ]
+then
+  usage
+fi
+
+while getopts "i:e:r:c:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    r)
+      RDS_NAME=$OPTARG
+      ;;
+    c)
+      COMMAND=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE"
+  || -z "$ENVIRONMENT"
+  || -z "$RDS_NAME"
+  || -z "$COMMAND"
+]]
+then
+  usage
+fi
+
+PROFILE="$(resolve_aws_profile -i "$INFRASTRUCTURE" -e "$ENVIRONMENT")"
+PROJECT_NAME="$(jq -r '.project_name' < "$CONFIG_SETUP_JSON_FILE")"
+RESOURCE_PREFIX_HASH="$(resource_prefix_hash -i "$INFRASTRUCTURE" -e "$ENVIRONMENT")"
+RDS_IDENTIFIER="$RESOURCE_PREFIX_HASH-$RDS_NAME"
+SECURITY_GROUP_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-rds-tooling-$RDS_NAME"
+CLUSTER_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-rds-tooling"
+TASK_DEF_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-rds-tooling-$RDS_NAME"
+LOG_GROUP_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-rds-tooling-$RDS_NAME"
+COMMAND="${COMMAND//\\/\\\\}"
+
+log_info -l "Finding $RDS_IDENTIFIER RDS ..." -q "$QUIET_MODE"
+
+set +e
+DB_CLUSTERS="$("$APP_ROOT/bin/dalmatian" aws-sso run-command \
+  -p "$PROFILE" \
+  rds describe-db-clusters \
+  --db-cluster-identifier "$RDS_IDENTIFIER" \
+  2>/dev/null)"
+set -e
+
+if [ -z "$DB_CLUSTERS" ]
+then
+  set +e
+  DB_INSTANCES="$("$APP_ROOT/bin/dalmatian" aws-sso run-command \
+    -p "$PROFILE" \
+    rds describe-db-instances \
+    --db-instance-identifier "$RDS_IDENTIFIER" \
+    2>/dev/null)"
+  set -e
+  if [ -z "$DB_INSTANCES" ]
+  then
+    err "RDS $RDS_IDENTIFIER does not exist"
+    exit 1
+  fi
+  DB_INFO="$(echo "$DB_INSTANCES" \
+    | jq -r \
+    '.DBInstances[0]')"
+  DB_SUBNET_GROUP="$(echo "$DB_INFO" \
+    | jq -r \
+    '.DBSubnetGroup.DBSubnetGroupName')"
+else
+  DB_INFO="$(echo "$DB_CLUSTERS" \
+    | jq -r \
+    '.DBClusters[0]')"
+  DB_SUBNET_GROUP="$(echo "$DB_INFO" \
+    | jq -r \
+    '.DBSubnetGroup')"
+fi
+
+DB_ENGINE="$(echo "$DB_INFO" \
+  | jq -r \
+  '.Engine')"
+DB_ENGINE="${DB_ENGINE#aurora-}"
+
+SECURITY_GROUP_IDS="$("$APP_ROOT/bin/dalmatian" aws-sso run-command \
+  -p "$PROFILE" \
+  ec2 describe-security-groups \
+  --filters "Name=group-name,Values=$SECURITY_GROUP_NAME" \
+  | jq -c \
+  '[.SecurityGroups[0].GroupId]')"
+
+DB_SUBNETS="$("$APP_ROOT/bin/dalmatian" aws-sso run-command \
+  -p "$PROFILE" \
+  rds describe-db-subnet-groups \
+  --db-subnet-group-name "$DB_SUBNET_GROUP" \
+  | jq -c \
+  '[.DBSubnetGroups[0].Subnets[].SubnetIdentifier]')"
+
+NETWORK_CONFIGURATION="awsvpcConfiguration={subnets=$DB_SUBNETS,securityGroups=$SECURITY_GROUP_IDS}"
+
+if [ "$DB_ENGINE" == "mysql" ]
+then
+  TASK_COMMAND="MYSQL_PWD=\$DB_PASSWORD mysql -u \$DB_USER -h \$DB_HOST -e '$COMMAND'"
+elif [ "$DB_ENGINE" == "postgresql" ]
+then
+  TASK_COMMAND="PGPASSWORD=\$DB_PASSWORD psql -U \$DB_USER -h \$DB_HOST -d postgres -c $COMMAND"
+else
+  err "Unrecognised engine: $ENGINE"
+fi
+
+TASK_OVERRIDES=$(jq -n \
+  --arg container_name "rds-tooling-$RDS_NAME" \
+  --arg task_command "$TASK_COMMAND" \
+  '{
+    "containerOverrides": [
+      {
+        "name": $container_name,
+        "command": [
+          "/bin/bash",
+          "-c",
+          $task_command
+        ]
+      }
+    ]
+  }'
+)
+
+log_info -l "Launching Fargate task to run command ..." -q "$QUIET_MODE"
+
+TASK="$("$APP_ROOT/bin/dalmatian" aws-sso run-command \
+  -p "$PROFILE" \
+  ecs run-task \
+    --cluster "$CLUSTER_NAME" \
+    --launch-type "FARGATE" \
+    --task-definition "$TASK_DEF_NAME" \
+    --network-configuration "$NETWORK_CONFIGURATION" \
+    --overrides "$TASK_OVERRIDES")"
+
+TASK_ARN="$(echo "$TASK" \
+  | jq -r \
+  '.tasks[0].taskArn')"
+TASK_ID="$(echo "$TASK_ARN" | cut -d'/' -f3)"
+
+log_info -l "Waiting for task to start running ...." -q "$QUIET_MODE"
+
+"$APP_ROOT/bin/dalmatian" aws-sso run-command \
+  -p "$PROFILE" \
+  ecs wait tasks-running \
+  --cluster "$CLUSTER_NAME" \
+  --tasks "$TASK_ARN"
+
+log_info -l "Tailing logs ..." -q "$QUIET_MODE"
+
+"$APP_ROOT/bin/dalmatian" aws-sso run-command \
+  -p "$PROFILE" \
+  logs tail "$LOG_GROUP_NAME" \
+  --log-stream-names "rds-tooling/rds-tooling-$RDS_NAME/$TASK_ID" \
+  --format short \
+  --follow &
+LOG_PID=$!
+
+"$APP_ROOT/bin/dalmatian" aws-sso run-command \
+  -p "$PROFILE" \
+  ecs wait tasks-stopped \
+  --cluster "$CLUSTER_NAME" \
+  --tasks "$TASK_ARN"
+
+log_info -l "Container stopped" -q "$QUIET_MODE"
+kill $LOG_PID

--- a/lib/bash-functions/resource_prefix_hash.sh
+++ b/lib/bash-functions/resource_prefix_hash.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Dalmatian specific function to get the resource prefix hash
+# from a given infrastructure name and environment
+#
+# @param -i <infrastructure_name>  An infrastructure's friendly name
+# @param -e <environment_name>     An infrastructure's environment name
+function resource_prefix_hash {
+  OPTIND=1
+  while getopts "i:e:" opt; do
+    case $opt in
+      i)
+        INFRASTRUCTURE_NAME="$OPTARG"
+        ;;
+      e)
+        ENVIRONMENT_NAME="$OPTARG"
+        ;;
+      *)
+        echo "Invalid \`resource_prefix_hash\` function usage" >&2
+        exit 1
+        ;;
+    esac
+  done
+  if [[
+    -n "$INFRASTRUCTURE_NAME"
+    && -n "$ENVIRONMENT_NAME"
+  ]]
+  then
+    PROJECT_NAME="$(jq -r '.project_name' < "$CONFIG_SETUP_JSON_FILE")"
+    RESOURCE_PREFIX_HASH="$(echo -n "$PROJECT_NAME-$INFRASTRUCTURE_NAME-$ENVIRONMENT_NAME" | sha512sum | head -c 8)"
+    if [[ $RESOURCE_PREFIX_HASH =~ ^[0-9] ]]
+    then
+      RESOURCE_PREFIX_HASH="h$RESOURCE_PREFIX_HASH"
+    fi
+    echo "$RESOURCE_PREFIX_HASH"
+  else
+    echo "Invalid \`resource_prefix_hash\` function usage" >&2
+    exit 1
+  fi
+}


### PR DESCRIPTION
* This command will launch a Fargate container, using the 'rds-tooling' image and task definition created by Dalmatian.
* The provided command will be used to overwrite the command in the original task definition.
* The command must be compatible with mysql or psql (eg. not a shell command). The engine will be selected based on the chosen RDS.
* Once the container has launched, the script will begin to tail logs for the running task, and will stop tailing when the container has stopped.
* Adds a `resource_prefix_hash` function, which returns the same resource prefix hash as is created in Terraform