### PR TITLE
Grab root password for RDS

### DIFF
--- a/bin/rds/v2/get-root-password
+++ b/bin/rds/v2/get-root-password
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: dalmatian $(basename "$(dirname "${BASH_SOURCE[0]}")") $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                     - help"
+  echo "  -i <infrastructure>    - infrastructure name"
+  echo "  -r <rds_name>          - RDS name (as defined in the Dalmatian config)"
+  echo "  -e <environment>       - environment name (e.g. 'staging' or 'prod')"
+  exit 1
+}
+
+# if there are no arguments passed exit with usage
+if [ $# -lt 1 ];
+then
+ usage
+fi
+
+while getopts "i:e:r:h" opt; do
+  case $opt in
+    i)
+      INFRASTRUCTURE_NAME=$OPTARG
+      ;;
+    e)
+      ENVIRONMENT=$OPTARG
+      ;;
+    r)
+      RDS_NAME=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$INFRASTRUCTURE_NAME"
+  || -z "$RDS_NAME"
+  || -z "$ENVIRONMENT"
+]]; then
+  usage
+fi
+
+PROFILE="$(resolve_aws_profile -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT")"
+PREFIX_HASH=$(resource_prefix_hash -i "${INFRASTRUCTURE_NAME}" -e "${ENVIRONMENT}")
+RDS_IDENTIFIER="$PREFIX_HASH-$RDS_NAME"
+SECRET_NAME="$PREFIX_HASH/rds/root-password/$RDS_NAME"
+
+log_info -l "Retrieving RDS root password from Secrets Manager..." -q "$QUIET_MODE"
+
+SECRET_ARN=$("$APP_ROOT/bin/dalmatian" aws run-command \
+  -p "$PROFILE" \
+  secretsmanager list-secrets \
+  --query "SecretList[?Name==\`$SECRET_NAME\`].ARN" \
+  --output text
+)
+RDS_ROOT_PASSWORD=$("$APP_ROOT/bin/dalmatian" aws run-command \
+  -p "$PROFILE" \
+  secretsmanager get-secret-value \
+  --secret-id "$SECRET_ARN" \
+  --query "SecretString" \
+  --output text)
+
+log_info -l "Finding $RDS_IDENTIFIER RDS ..." -q "$QUIET_MODE"
+
+set +e
+DB_CLUSTERS="$("$APP_ROOT/bin/dalmatian" aws run-command \
+  -p "$PROFILE" \
+  rds describe-db-clusters \
+  --db-cluster-identifier "$RDS_IDENTIFIER" \
+  2>/dev/null)"
+set -e
+
+if [ -z "$DB_CLUSTERS" ]
+then
+  set +e
+  DB_INSTANCES="$("$APP_ROOT/bin/dalmatian" aws run-command \
+    -p "$PROFILE" \
+    rds describe-db-instances \
+    --db-instance-identifier "$RDS_IDENTIFIER" \
+    2>/dev/null)"
+  set -e
+
+  if [ -z "$DB_INSTANCES" ]
+  then
+    err "RDS $RDS_NAME does not exist"
+    exit 1
+  fi
+
+  RDS_USER_NAME="$(echo "$DB_INSTANCES" \
+    | jq -r \
+    '.DBInstances[0].MasterUsername')"
+else
+  RDS_USER_NAME="$(echo "$DB_CLUSTERS" \
+    | jq -r \
+    '.DBClusters[0].MasterUsername')"
+fi
+
+if [[ $QUIET_MODE == "0" ]];
+then
+  echo "Root username: $RDS_USER_NAME"
+  echo "Root password: $RDS_ROOT_PASSWORD"
+else
+  echo "$RDS_ROOT_PASSWORD"
+fi


### PR DESCRIPTION
- Uses AWS Secrets Manager to grab the RDS password, and prints it to screen along with the root username.

If `-q` is passed, it will simply print the password on it's own.