### PR TITLE
Change `rds tooling-container-run-command` to `utilities run-command`

### DIFF
--- a/bin/rds/v2/run-command
+++ b/bin/rds/v2/run-command
@@ -53,7 +53,7 @@ then
   usage
 fi
 
-"$APP_ROOT/bin/dalmatian" rds tooling-container-run-command \
+"$APP_ROOT/bin/dalmatian" utilities run-command \
   -i "$INFRASTRUCTURE" \
   -e "$ENVIRONMENT" \
   -r "$RDS_NAME" \

--- a/bin/rds/v2/shell
+++ b/bin/rds/v2/shell
@@ -59,7 +59,7 @@ then
   usage
 fi
 
-"$APP_ROOT/bin/dalmatian" rds tooling-container-run-command \
+"$APP_ROOT/bin/dalmatian" utilities run-command \
   -i "$INFRASTRUCTURE" \
   -e "$ENVIRONMENT" \
   -r "$RDS_NAME" \

--- a/bin/utilities/v2/run-command
+++ b/bin/utilities/v2/run-command
@@ -10,7 +10,7 @@ usage() {
   echo "  -i <infrastructure>                  - infrastructure name"
   echo "  -r <rds_name>                        - RDS name (as defined in the Dalmatian config)"
   echo "  -e <environment>                     - environment name (e.g. 'staging' or 'prod')"
-  echo "  -c <command>                         - The command to run in the RDS tooling container"
+  echo "  -c <command>                         - The command to run in the utilities container"
   echo "  -s                                   - Run the command on the RDS rather than the container"
   echo "  -I                                   - Run an interactive shell (Optional)"
   echo "  -D <keep>_alive_delay>               - delay in seconds to check for mysql/psql/bash processes before exiting the interactive shell (default 60)"
@@ -67,77 +67,98 @@ if [[
   -z "$INFRASTRUCTURE"
   || ( -z "$COMMAND" && "$INTERACTIVE" == "0" )
   || -z "$ENVIRONMENT"
-  || -z "$RDS_NAME"
 ]]
 then
+  usage
+fi
+
+if [[
+  "$RUN_ON_RDS" == 1
+  && -z "$RUN_ON_RDS"
+]]
+then
+  err "An RDS name must be provided to run a command on an RDS"
   usage
 fi
 
 PROFILE="$(resolve_aws_profile -i "$INFRASTRUCTURE" -e "$ENVIRONMENT")"
 PROJECT_NAME="$(jq -r '.project_name' < "$CONFIG_SETUP_JSON_FILE")"
 RESOURCE_PREFIX_HASH="$(resource_prefix_hash -i "$INFRASTRUCTURE" -e "$ENVIRONMENT")"
-RDS_IDENTIFIER="$RESOURCE_PREFIX_HASH-$RDS_NAME"
-SECURITY_GROUP_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-rds-tooling-$RDS_NAME"
-CLUSTER_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-rds-tooling"
-TASK_DEF_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-rds-tooling-$RDS_NAME"
-LOG_GROUP_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-rds-tooling-$RDS_NAME"
+CLUSTER_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-utilities"
 COMMAND="${COMMAND//\\/\\\\}"
 
-log_info -l "Finding $RDS_IDENTIFIER RDS ..." -q "$QUIET_MODE"
-
-set +e
-DB_CLUSTERS="$("$APP_ROOT/bin/dalmatian" aws run-command \
-  -p "$PROFILE" \
-  rds describe-db-clusters \
-  --db-cluster-identifier "$RDS_IDENTIFIER" \
-  2>/dev/null)"
-set -e
-
-if [ -z "$DB_CLUSTERS" ]
+if [ -n "$RDS_NAME" ]
 then
+  RDS_IDENTIFIER="$RESOURCE_PREFIX_HASH-$RDS_NAME"
+  SECURITY_GROUP_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-utilities-$RDS_NAME"
+  TASK_DEF_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-utilities-$RDS_NAME"
+  LOG_GROUP_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-utilities-$RDS_NAME"
+
+  log_info -l "Finding $RDS_IDENTIFIER RDS ..." -q "$QUIET_MODE"
+  
   set +e
-  DB_INSTANCES="$("$APP_ROOT/bin/dalmatian" aws run-command \
+  DB_CLUSTERS="$("$APP_ROOT/bin/dalmatian" aws run-command \
     -p "$PROFILE" \
-    rds describe-db-instances \
-    --db-instance-identifier "$RDS_IDENTIFIER" \
+    rds describe-db-clusters \
+    --db-cluster-identifier "$RDS_IDENTIFIER" \
     2>/dev/null)"
   set -e
-  if [ -z "$DB_INSTANCES" ]
-  then
-    err "RDS $RDS_IDENTIFIER does not exist"
-    exit 1
-  fi
-  DB_INFO="$(echo "$DB_INSTANCES" \
-    | jq -r \
-    '.DBInstances[0]')"
-  DB_SUBNET_GROUP="$(echo "$DB_INFO" \
-    | jq -r \
-    '.DBSubnetGroup.DBSubnetGroupName')"
-else
-  DB_INFO="$(echo "$DB_CLUSTERS" \
-    | jq -r \
-    '.DBClusters[0]')"
-  DB_SUBNET_GROUP="$(echo "$DB_INFO" \
-    | jq -r \
-    '.DBSubnetGroup')"
-fi
-
-if [ "$RUN_ON_RDS" == "1" ]
-then
-  DB_ENGINE="$(echo "$DB_INFO" \
-    | jq -r \
-    '.Engine')"
-  DB_ENGINE="${DB_ENGINE#aurora-}"
   
-  if [ "$DB_ENGINE" == "mysql" ]
+  if [ -z "$DB_CLUSTERS" ]
   then
-    COMMAND="MYSQL_PWD=\$DB_PASSWORD mysql -u \$DB_USER -h \$DB_HOST -e '$COMMAND'"
-  elif [ "$DB_ENGINE" == "postgresql" ]
-  then
-    COMMAND="PGPASSWORD=\$DB_PASSWORD psql -U \$DB_USER -h \$DB_HOST -d postgres -c $COMMAND"
+    set +e
+    DB_INSTANCES="$("$APP_ROOT/bin/dalmatian" aws run-command \
+      -p "$PROFILE" \
+      rds describe-db-instances \
+      --db-instance-identifier "$RDS_IDENTIFIER" \
+      2>/dev/null)"
+    set -e
+    if [ -z "$DB_INSTANCES" ]
+    then
+      err "RDS $RDS_IDENTIFIER does not exist"
+      exit 1
+    fi
+    DB_INFO="$(echo "$DB_INSTANCES" \
+      | jq -r \
+      '.DBInstances[0]')"
+    DB_SUBNET_GROUP="$(echo "$DB_INFO" \
+      | jq -r \
+      '.DBSubnetGroup.DBSubnetGroupName')"
   else
-    err "Unrecognised engine: $ENGINE"
+    DB_INFO="$(echo "$DB_CLUSTERS" \
+      | jq -r \
+      '.DBClusters[0]')"
+    DB_SUBNET_GROUP="$(echo "$DB_INFO" \
+      | jq -r \
+      '.DBSubnetGroup')"
   fi
+  
+  if [ "$RUN_ON_RDS" == "1" ]
+  then
+    DB_ENGINE="$(echo "$DB_INFO" \
+      | jq -r \
+      '.Engine')"
+    DB_ENGINE="${DB_ENGINE#aurora-}"
+    
+    if [ "$DB_ENGINE" == "mysql" ]
+    then
+      COMMAND="MYSQL_PWD=\$DB_PASSWORD mysql -u \$DB_USER -h \$DB_HOST -e '$COMMAND'"
+    elif [ "$DB_ENGINE" == "postgresql" ]
+    then
+      COMMAND="PGPASSWORD=\$DB_PASSWORD psql -U \$DB_USER -h \$DB_HOST -d postgres -c $COMMAND"
+    else
+      err "Unrecognised engine: $ENGINE"
+    fi
+  fi
+
+  DB_SUBNETS="$("$APP_ROOT/bin/dalmatian" aws run-command \
+    -p "$PROFILE" \
+    rds describe-db-subnet-groups \
+    --db-subnet-group-name "$DB_SUBNET_GROUP" \
+    | jq -c \
+    '[.DBSubnetGroups[0].Subnets[].SubnetIdentifier]')"
+
+  CONTAINER_NAME="utilities-$RDS_NAME"
 fi
 
 SECURITY_GROUP_IDS="$("$APP_ROOT/bin/dalmatian" aws run-command \
@@ -147,19 +168,12 @@ SECURITY_GROUP_IDS="$("$APP_ROOT/bin/dalmatian" aws run-command \
   | jq -c \
   '[.SecurityGroups[0].GroupId]')"
 
-DB_SUBNETS="$("$APP_ROOT/bin/dalmatian" aws run-command \
-  -p "$PROFILE" \
-  rds describe-db-subnet-groups \
-  --db-subnet-group-name "$DB_SUBNET_GROUP" \
-  | jq -c \
-  '[.DBSubnetGroups[0].Subnets[].SubnetIdentifier]')"
-
 NETWORK_CONFIGURATION="awsvpcConfiguration={subnets=$DB_SUBNETS,securityGroups=$SECURITY_GROUP_IDS}"
 
 if [ "$INTERACTIVE" == 1 ]
 then
   TASK_OVERRIDES=$(jq -n \
-    --arg container_name "rds-tooling-$RDS_NAME" \
+    --arg container_name "$CONTAINER_NAME" \
     --arg delay "$KEEP_ALIVE_DELAY" \
     --arg max_keepalive "$KEEP_ALIVE_MAX_LIFETIME" \
     '{
@@ -213,7 +227,7 @@ then
       ecs execute-command \
         --cluster "$CLUSTER_NAME" \
         --task "$TASK_ARN" \
-        --container "rds-tooling-$RDS_NAME" \
+        --container "$CONTAINER_NAME" \
         --command "/bin/bash -c 'echo ssm-agent check'" \
         --interactive \
         > /dev/null 2>&1 \
@@ -240,7 +254,7 @@ then
     log_info -l "Executing $DB_ENGINE shell on $RDS_IDENTIFIER ..." -q "$QUIET_MODE"
   else
     COMMAND="/bin/bash"
-    log_info -l "Executing shell on rds-tooling container ..." -q "$QUIET_MODE"
+    log_info -l "Executing shell on utilities container ..." -q "$QUIET_MODE"
   fi
 
   "$APP_ROOT/bin/dalmatian" aws run-command \
@@ -248,7 +262,7 @@ then
   ecs execute-command \
     --cluster "$CLUSTER_NAME" \
     --task "$TASK_ARN" \
-    --container "rds-tooling-$RDS_NAME" \
+    --container "$CONTAINER_NAME" \
     --command "$COMMAND" \
     --interactive
 
@@ -256,7 +270,7 @@ then
 fi
 
 TASK_OVERRIDES=$(jq -n \
-  --arg container_name "rds-tooling-$RDS_NAME" \
+  --arg container_name "$CONTAINER_NAME" \
   --arg task_command "$COMMAND" \
   '{
     "containerOverrides": [
@@ -301,7 +315,7 @@ log_info -l "Tailing logs ..." -q "$QUIET_MODE"
 "$APP_ROOT/bin/dalmatian" aws run-command \
   -p "$PROFILE" \
   logs tail "$LOG_GROUP_NAME" \
-  --log-stream-names "rds-tooling/rds-tooling-$RDS_NAME/$TASK_ID" \
+  --log-stream-names "/utilities/$CONTAINER_NAME/$TASK_ID" \
   --format short \
   --follow &
 LOG_PID=$!

--- a/terraform-project-versions.json
+++ b/terraform-project-versions.json
@@ -1,4 +1,4 @@
 {
   "terraform-dxw-dalmatian-account-bootstrap": "v0.13.3",
-  "terraform-dxw-dalmatian-infrastructure": "v0.40.2"
+  "terraform-dxw-dalmatian-infrastructure": "v0.41.0"
 }


### PR DESCRIPTION
* The RDS Tooling container has been changed to a more generic Utilities container (Along with the task definition)
* This changes the command to select the correct task definition (If an RDS name is supplied), and moves it to the more generic `utilities run-command` command. The `rds shell` and `rds run-command` scripts have been updated to use this new command