### PR TITLE
Special case the addition of a letter to the hash

### DIFF
--- a/bin/utilities/v2/run-command
+++ b/bin/utilities/v2/run-command
@@ -83,7 +83,7 @@ fi
 
 PROFILE="$(resolve_aws_profile -i "$INFRASTRUCTURE" -e "$ENVIRONMENT")"
 PROJECT_NAME="$(jq -r '.project_name' < "$CONFIG_SETUP_JSON_FILE")"
-RESOURCE_PREFIX_HASH="$(resource_prefix_hash -i "$INFRASTRUCTURE" -e "$ENVIRONMENT")"
+RESOURCE_PREFIX_HASH="$(resource_prefix_hash -i "$INFRASTRUCTURE" -e "$ENVIRONMENT" -l)"
 CLUSTER_NAME="$PROJECT_NAME-$INFRASTRUCTURE-$ENVIRONMENT-infrastructure-utilities"
 COMMAND="${COMMAND//\\/\\\\}"
 

--- a/lib/bash-functions/resource_prefix_hash.sh
+++ b/lib/bash-functions/resource_prefix_hash.sh
@@ -9,13 +9,17 @@ set -o pipefail
 # @param -e <environment_name>     An infrastructure's environment name
 function resource_prefix_hash {
   OPTIND=1
-  while getopts "i:e:" opt; do
+  LETTER_START=0
+  while getopts "i:e:l" opt; do
     case $opt in
       i)
         INFRASTRUCTURE_NAME="$OPTARG"
         ;;
       e)
         ENVIRONMENT_NAME="$OPTARG"
+        ;;
+      l)
+        LETTER_START=1
         ;;
       *)
         echo "Invalid \`resource_prefix_hash\` function usage" >&2
@@ -30,9 +34,12 @@ function resource_prefix_hash {
   then
     PROJECT_NAME="$(jq -r '.project_name' < "$CONFIG_SETUP_JSON_FILE")"
     RESOURCE_PREFIX_HASH="$(echo -n "$PROJECT_NAME-$INFRASTRUCTURE_NAME-$ENVIRONMENT_NAME" | sha512sum | head -c 8)"
-    if [[ $RESOURCE_PREFIX_HASH =~ ^[0-9] ]]
+    if [[ $LETTER_START -eq 1 ]]
     then
+      if [[ $RESOURCE_PREFIX_HASH =~ ^[0-9] ]]
+      then
       RESOURCE_PREFIX_HASH="h$RESOURCE_PREFIX_HASH"
+    fi
     fi
     echo "$RESOURCE_PREFIX_HASH"
   else


### PR DESCRIPTION
Not all things we use the infrastructure environment hash for need
to have a letter prepended if the hash starts with a number.

This special cases this with an option and then uses it for rds names.