### PR TITLE
Refactor logging to use log_info and log_msg

### DIFF
--- a/bin/aurora/v1/create-database
+++ b/bin/aurora/v1/create-database
@@ -72,7 +72,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -84,7 +84,7 @@ RDS_ROOT_PASSWORD=$(
     | jq -r .Parameters[0].Value
 )
 
-echo "==> Getting RDS info..."
+log_info -l "Getting RDS info..." -q "$QUIET_MODE"
 
 RDS_INFO=$(
   aws rds describe-db-clusters \
@@ -93,18 +93,18 @@ RDS_INFO=$(
 RDS_ENGINE=$(echo "$RDS_INFO" | jq -r .DBClusters[0].Engine)
 RDS_ROOT_USERNAME=$(echo "$RDS_INFO" | jq -r .DBClusters[0].MasterUsername)
 
-echo "Engine: $RDS_ENGINE"
-echo "Root username: $RDS_ROOT_USERNAME"
+log_msg -l "Engine: $RDS_ENGINE" -q "$QUIET_MODE"
+log_msg -l "Root username: $RDS_ROOT_USERNAME" -q "$QUIET_MODE"
 
 ECS_INSTANCE_ID=${ECS_INSTANCE_ID:-$(pick_ecs_instance -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT")}
 
-echo "ECS instance ID: $ECS_INSTANCE_ID"
+log_msg -l "ECS instance ID: $ECS_INSTANCE_ID" -q "$QUIET_MODE"
 
-echo "==> Creating database..."
+log_info -l "Creating database..." -q "$QUIET_MODE"
 
 aws ssm start-session \
   --target "$ECS_INSTANCE_ID" \
   --document-name "$RDS_IDENTIFIER-aurora-db-creation" \
   --parameters "RootPassword=$RDS_ROOT_PASSWORD,NewDbName=$DB_NAME,NewUserName=$USER_NAME,NewUserPassword=$USER_PASSWORD"
 
-echo "Success!"
+log_info -l "Success!" -q "$QUIET_MODE"

--- a/bin/aurora/v1/export-dump
+++ b/bin/aurora/v1/export-dump
@@ -73,7 +73,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -85,7 +85,7 @@ RDS_ROOT_PASSWORD=$(
     | jq -r .Parameters[0].Value
 )
 
-echo "==> Getting RDS info..."
+log_info -l "Getting RDS info..." -q "$QUIET_MODE"
 
 RDS_INFO=$(
   aws rds describe-db-clusters \
@@ -108,15 +108,15 @@ aws ssm start-session \
   --document-name "$RDS_IDENTIFIER-aurora-sql-dump" \
   --parameters "RootPassword=$RDS_ROOT_PASSWORD,DatabaseName=$DATABASE_NAME"
 
-echo "==> Export complete"
+log_info -l "Export complete" -q "$QUIET_MODE"
 
 SQL_FILE_NAME="$DATABASE_NAME-$ENVIRONMENT-sql-export.sql"
 S3_BUCKET_NAME="$INFRASTRUCTURE_NAME-ecs-$ENVIRONMENT-dalmatian-transfer"
 
-echo "==> Starting download of $SQL_FILE_NAME from s3 bucket $S3_BUCKET_NAME..."
+log_info -l "Starting download of $SQL_FILE_NAME from s3 bucket $S3_BUCKET_NAME..." -q "$QUIET_MODE"
 
 aws s3 cp "s3://$S3_BUCKET_NAME/db_exports/$SQL_FILE_NAME" "$OUTPUT_FILE_PATH"
 
-echo "==> Deleting sql file from S3 ..."
+log_info -l "Deleting sql file from S3 ..." -q "$QUIET_MODE"
 
 aws s3 rm "s3://$S3_BUCKET_NAME/db_exports/$SQL_FILE_NAME"

--- a/bin/aurora/v1/get-root-password
+++ b/bin/aurora/v1/get-root-password
@@ -52,7 +52,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -64,7 +64,7 @@ RDS_ROOT_PASSWORD=$(
     | jq -r .Parameters[0].Value
 )
 
-echo "==> Getting RDS info..."
+log_info -l "Getting RDS info..." -q "$QUIET_MODE"
 
 RDS_INFO=$(
   aws rds describe-db-clusters \

--- a/bin/aurora/v1/import-dump
+++ b/bin/aurora/v1/import-dump
@@ -75,7 +75,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -87,7 +87,7 @@ RDS_ROOT_PASSWORD=$(
     | jq -r .Parameters[0].Value
 )
 
-echo "==> Getting RDS info..."
+log_info -l "Getting RDS info..." -q "$QUIET_MODE"
 
 RDS_INFO=$(
   aws rds describe-db-clusters \
@@ -96,12 +96,12 @@ RDS_INFO=$(
 RDS_ENGINE=$(echo "$RDS_INFO" | jq -r .DBClusters[0].Engine)
 RDS_ROOT_USERNAME=$(echo "$RDS_INFO" | jq -r .DBClusters[0].MasterUsername)
 
-echo "Engine: $RDS_ENGINE"
-echo "Root username: $RDS_ROOT_USERNAME"
+log_msg -l "Engine: $RDS_ENGINE" -q "$QUIET_MODE"
+log_msg -l "Root username: $RDS_ROOT_USERNAME" -q "$QUIET_MODE"
 
 ECS_INSTANCE_ID=${ECS_INSTANCE_ID:-$(pick_ecs_instance -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT")}
 
-echo "ECS instance ID: $ECS_INSTANCE_ID"
+log_msg -l "ECS instance ID: $ECS_INSTANCE_ID" -q "$QUIET_MODE"
 
 if [ ! -f "$DB_DUMP_FILE" ];
 then
@@ -121,38 +121,38 @@ then
   DB_DUMP_FILE="$OUTPUT_PATH/$DB_DUMP_FILE"
 fi
 
-echo "--------------------------------------------------"
-echo "The RDS:"
-echo "  $RDS_IDENTIFIER"
-echo "in the infrastructure:"
-echo "  $INFRASTRUCTURE_NAME"
-echo "in environment:"
-echo "  $ENVIRONMENT"
-echo "will have the database:"
-echo "  $DATABASE_NAME"
-echo "overwritten with the file:"
-echo "  $DB_DUMP_FILE"
-echo "--------------------------------------------------"
-echo ""
-echo "Are you sure?"
-echo ""
+log_msg -l "--------------------------------------------------" -q "$QUIET_MODE"
+log_msg -l "The RDS:" -q "$QUIET_MODE"
+log_msg -l "  $RDS_IDENTIFIER" -q "$QUIET_MODE"
+log_msg -l "in the infrastructure:" -q "$QUIET_MODE"
+log_msg -l "  $INFRASTRUCTURE_NAME" -q "$QUIET_MODE"
+log_msg -l "in environment:" -q "$QUIET_MODE"
+log_msg -l "  $ENVIRONMENT" -q "$QUIET_MODE"
+log_msg -l "will have the database:" -q "$QUIET_MODE"
+log_msg -l "  $DATABASE_NAME" -q "$QUIET_MODE"
+log_msg -l "overwritten with the file:" -q "$QUIET_MODE"
+log_msg -l "  $DB_DUMP_FILE" -q "$QUIET_MODE"
+log_msg -l "--------------------------------------------------" -q "$QUIET_MODE"
+log_msg -l "" -q "$QUIET_MODE"
+log_msg -l "Are you sure?" -q "$QUIET_MODE"
+log_msg -l "" -q "$QUIET_MODE"
 
-echo "Continue (Yes/No)"
+log_msg -l "Continue (Yes/No)" -q "$QUIET_MODE"
 read -r -p " > " choice
 case "$choice" in
-  Yes ) echo "==> Importing ...";;
+  Yes ) log_info -l "Importing ..." -q "$QUIET_MODE";;
   * ) err "You must specify 'Yes' to continue. The import has been cancelled."
     exit 1
     ;;
 esac
 
-echo "Uploading $DB_DUMP_FILE ..."
+log_msg -l "Uploading $DB_DUMP_FILE ..." -q "$QUIET_MODE"
 
 "$APP_ROOT/bin/ecs/v1/file-upload" -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT" -s "$DB_DUMP_FILE" -t "/tmp/$(basename "$DB_DUMP_FILE")" -I "$ECS_INSTANCE_ID"
 
-echo "==> Uploading complete!"
+log_info -l "Uploading complete!" -q "$QUIET_MODE"
 
-echo "==> Starting import of $RDS_ENGINE $DB_DUMP_FILE file into $RDS_IDENTIFIER..."
+log_info -l "Starting import of $RDS_ENGINE $DB_DUMP_FILE file into $RDS_IDENTIFIER..." -q "$QUIET_MODE"
 
 aws ssm start-session \
   --target "$ECS_INSTANCE_ID" \

--- a/bin/aurora/v1/list-databases
+++ b/bin/aurora/v1/list-databases
@@ -53,7 +53,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -67,13 +67,13 @@ RDS_ROOT_PASSWORD=$(
 
 ECS_INSTANCE_ID=${ECS_INSTANCE_ID:-$(pick_ecs_instance -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT")}
 
-echo "ECS instance ID: $ECS_INSTANCE_ID"
+log_info -l "ECS instance ID: $ECS_INSTANCE_ID" -q "$QUIET_MODE"
 
-echo "==> Listing databases..."
+log_info -l "Listing databases..." -q "$QUIET_MODE"
 
 aws ssm start-session \
   --target "$ECS_INSTANCE_ID" \
   --document-name "$RDS_IDENTIFIER-aurora-db-list" \
   --parameters "RootPassword=$RDS_ROOT_PASSWORD"
 
-echo "Success!"
+log_info -l "Success!" -q "$QUIET_MODE"

--- a/bin/aurora/v1/list-instances
+++ b/bin/aurora/v1/list-instances
@@ -43,7 +43,7 @@ then
   usage
 fi
 
-echo "==> Getting RDS instances in $INFRASTRUCTURE_NAME $ENVIRONMENT..."
+log_info -l "Getting RDS instances in $INFRASTRUCTURE_NAME $ENVIRONMENT..." -q "$QUIET_MODE"
 
 RDS_IDENTIFIER_SEARCH="${INFRASTRUCTURE_NAME//-/}.*${ENVIRONMENT//-/}"
 

--- a/bin/aurora/v1/set-root-password
+++ b/bin/aurora/v1/set-root-password
@@ -57,7 +57,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Setting RDS root password in Parameter Store..."
+log_info -l "Setting RDS root password in Parameter Store..." -q "$QUIET_MODE"
 
 aws ssm put-parameter \
    --name "/$INFRASTRUCTURE_NAME/$RDS_IDENTIFIER-aurora/password" \
@@ -66,7 +66,7 @@ aws ssm put-parameter \
    --key-id "alias/$INFRASTRUCTURE_NAME-$RDS_NAME-aurora-$ENVIRONMENT-aurora-values-ssm" \
    --overwrite
 
-echo "==> Parameter store value set"
+log_info -l "Parameter store value set" -q "$QUIET_MODE"
 echo "==> For this change to take effect, run the following from dalmatian core to deploy:"
 echo ""
 echo "    ./scripts/bin/deploy -i $INFRASTRUCTURE_NAME -e $ENVIRONMENT -S rds,hosted-zone,vpn-customer-gateway,ecs,ecs-services,elasticache-cluster,shared-loadbalancer,waf"

--- a/bin/aurora/v1/shell
+++ b/bin/aurora/v1/shell
@@ -57,7 +57,7 @@ fi
 
 if [ -n "$LIST" ];
 then
-  echo "==> Finding ECS instances..."
+  log_info -l "Finding ECS instances..." -q "$QUIET_MODE"
   INSTANCES=$(aws ec2 describe-instances --filters Name=instance-state-code,Values=16 Name=tag:Name,Values="$INFRASTRUCTURE_NAME-$ENVIRONMENT*")
 
   AVAILABLE_INSTANCES=$(echo "$INSTANCES" | jq -r '.Reservations[].Instances[] | (.InstanceId) + " | " + (.Tags[] | select(.Key == "Name") | .Value) + " | " + (.LaunchTime)')
@@ -70,7 +70,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -82,7 +82,7 @@ RDS_ROOT_PASSWORD=$(
     | jq -r .Parameters[0].Value
 )
 
-echo "==> Getting RDS info..."
+log_info -l "Getting RDS info..." -q "$QUIET_MODE"
 
 RDS_INFO=$(
   aws rds describe-db-clusters \
@@ -98,7 +98,7 @@ ECS_INSTANCE_ID=${ECS_INSTANCE_ID:-$(pick_ecs_instance -i "$INFRASTRUCTURE_NAME"
 
 echo "ECS instance ID: $ECS_INSTANCE_ID"
 
-echo "==> Starting $RDS_ENGINE session on $RDS_IDENTIFIER..."
+log_info -l "Starting $RDS_ENGINE session on $RDS_IDENTIFIER..." -q "$QUIET_MODE"
 set -x
 aws ssm start-session \
   --target "$ECS_INSTANCE_ID" \

--- a/bin/aurora/v1/start-sql-backup-to-s3
+++ b/bin/aurora/v1/start-sql-backup-to-s3
@@ -63,4 +63,4 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
 # run the backup task
 aws ecs run-task --no-cli-pager --cluster "$CLUSTER_NAME" --task-definition "arn:aws:ecs:eu-west-2:$ACCOUNT_ID:task-definition/$TASK_NAME"
-echo "==> Started backup task $TASK_NAME for RDS instance $RDS_IDENTIFIER"
+log_info -l "Started backup task $TASK_NAME for RDS instance $RDS_IDENTIFIER" -q "$QUIET_MODE"

--- a/bin/aws/v1/assume-infrastructure-role
+++ b/bin/aws/v1/assume-infrastructure-role
@@ -4,6 +4,23 @@
 set -e
 set -o pipefail
 
+if [ -z "$APP_ROOT" ]; then
+  APP_ROOT="$( cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd -P)"
+fi
+
+if ! command -v log_info > /dev/null; then
+  for f in "$APP_ROOT"/lib/bash-functions/*; do
+    if [ -f "$f" ]; then
+      source "$f"
+      while IFS='' read -r function_name; do
+        export -f "${function_name?}"
+      done < <(grep "^function" "$f" | cut -d" " -f2)
+    fi
+  done
+fi
+
+QUIET_MODE="${QUIET_MODE:-0}"
+
 usage() {
   echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
   echo "  -h                       - help"
@@ -39,11 +56,11 @@ if [ -z "$DALMATIAN_CONFIG_PATH" ]
 then
 "$APP_ROOT/bin/dalmatian-refresh-config" > /dev/null
 
-echo "==> Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure account ..."
+log_info -l "Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure account ..." -q "$QUIET_MODE"
 
 INFRASTRUCTURE_ACCOUNT_ID=$(yq e ".infrastructures.$INFRASTRUCTURE_NAME.account_id" "$APP_ROOT/bin/tmp/dalmatian-config/dalmatian.yml")
 else
-  echo "==> Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure account ..."
+  log_info -l "Assuming role to provide access to $INFRASTRUCTURE_NAME infrastructure account ..." -q "$QUIET_MODE"
 
 INFRASTRUCTURE_ACCOUNT_ID=$(yq e ".infrastructures.$INFRASTRUCTURE_NAME.account_id" "$DALMATIAN_CONFIG_PATH")
 

--- a/bin/aws/v1/assume-infrastructure-role
+++ b/bin/aws/v1/assume-infrastructure-role
@@ -11,6 +11,7 @@ fi
 if ! command -v log_info > /dev/null; then
   for f in "$APP_ROOT"/lib/bash-functions/*; do
     if [ -f "$f" ]; then
+      # shellcheck disable=SC1090
       source "$f"
       while IFS='' read -r function_name; do
         export -f "${function_name?}"

--- a/bin/aws/v1/awscli-version
+++ b/bin/aws/v1/awscli-version
@@ -4,6 +4,23 @@
 set -e
 set -o pipefail
 
+if [ -z "$APP_ROOT" ]; then
+  APP_ROOT="$( cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd -P)"
+fi
+
+if ! command -v log_info > /dev/null; then
+  for f in "$APP_ROOT"/lib/bash-functions/*; do
+    if [ -f "$f" ]; then
+      source "$f"
+      while IFS='' read -r function_name; do
+        export -f "${function_name?}"
+      done < <(grep "^function" "$f" | cut -d" " -f2)
+    fi
+  done
+fi
+
+QUIET_MODE="${QUIET_MODE:-0}"
+
 usage() {
   echo "Check if awscli is installed and compatible with dalmatian-tools"
   exit 1

--- a/bin/aws/v1/awscli-version
+++ b/bin/aws/v1/awscli-version
@@ -11,6 +11,7 @@ fi
 if ! command -v log_info > /dev/null; then
   for f in "$APP_ROOT"/lib/bash-functions/*; do
     if [ -f "$f" ]; then
+      # shellcheck disable=SC1090
       source "$f"
       while IFS='' read -r function_name; do
         export -f "${function_name?}"

--- a/bin/aws/v1/instance-shell
+++ b/bin/aws/v1/instance-shell
@@ -25,10 +25,10 @@ fi
 
 if ! command -v session-manager-plugin > /dev/null
 then
-  echo "This script requires the \`session-manager-plugin\` to be installed:"
-  echo "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-  echo "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:"
-  echo "softwareupdate --install-rosetta"
+  err "This script requires the \`session-manager-plugin\` to be installed"
+  log_info -l "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" -q "$QUIET_MODE"
+  log_info -l "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:" -q "$QUIET_MODE"
+  log_info -l "softwareupdate --install-rosetta" -q "$QUIET_MODE"
   exit 1
 fi
 
@@ -61,7 +61,7 @@ fi
 
 if [ -n "$LIST" ];
 then
-  echo "==> Finding ECS instance..."
+  log_info -l "Finding ECS instance..." -q "$QUIET_MODE"
   INSTANCES=$(aws ec2 describe-instances --filters Name=instance-state-code,Values=16)
   AVAILABLE_INSTANCES=$(echo "$INSTANCES" | jq -r '.Reservations[].Instances[] | (.InstanceId) + " | " + (.LaunchTime)')
   echo "$AVAILABLE_INSTANCES"
@@ -69,6 +69,6 @@ then
 fi
 
 
-echo "==> Connecting to $INSTANCE_ID..."
+log_info -l "Connecting to $INSTANCE_ID..." -q "$QUIET_MODE"
 
 aws ssm start-session --target "$INSTANCE_ID"

--- a/bin/aws/v1/key-age
+++ b/bin/aws/v1/key-age
@@ -31,7 +31,7 @@ metadata=$(aws iam list-access-keys --user-name "$AWS_CALLER_IDENTITY_USERNAME")
 # Check if any access keys were found
 if [[ $(echo "$metadata" | jq '.AccessKeyMetadata | length') == 0 ]]
 then
-  echo "No Access Keys were found for user '$AWS_CALLER_IDENTITY_USERNAME'"
+  err "No Access Keys were found for user '$AWS_CALLER_IDENTITY_USERNAME'"
   exit 1
 fi
 
@@ -51,6 +51,6 @@ for key in $(echo "$metadata" | jq -r '.AccessKeyMetadata[] | @base64'); do
   # Check if access key is more than 180 days old and prompt user to rotate if it is
   if [[ $age -gt 180 ]]
   then
-    echo "[i] Warning: Access key is more than 180 days old and should be rotated."
+    warning "Access key is more than 180 days old and should be rotated."
   fi
 done

--- a/bin/aws/v1/mfa
+++ b/bin/aws/v1/mfa
@@ -11,6 +11,7 @@ fi
 if ! command -v log_info > /dev/null; then
   for f in "$APP_ROOT"/lib/bash-functions/*; do
     if [ -f "$f" ]; then
+      #shellcheck disable=SC1090
       source "$f"
       while IFS='' read -r function_name; do
         export -f "${function_name?}"

--- a/bin/aws/v1/mfa
+++ b/bin/aws/v1/mfa
@@ -4,6 +4,23 @@
 set -e
 set -o pipefail
 
+if [ -z "$APP_ROOT" ]; then
+  APP_ROOT="$( cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd -P)"
+fi
+
+if ! command -v log_info > /dev/null; then
+  for f in "$APP_ROOT"/lib/bash-functions/*; do
+    if [ -f "$f" ]; then
+      source "$f"
+      while IFS='' read -r function_name; do
+        export -f "${function_name?}"
+      done < <(grep "^function" "$f" | cut -d" " -f2)
+    fi
+  done
+fi
+
+QUIET_MODE="${QUIET_MODE:-0}"
+
 DALMATIAN_MFA_CREDENTIALS_FILE="$HOME/.config/dalmatian/mfa_credentials.json"
 
 usage() {
@@ -17,8 +34,7 @@ usage() {
 
 EXPORT_TO_STDOUT=0
 
-while getopts "m:eh" opt;
-do
+while getopts "m:eh" opt; do
   case $opt in
     m)
       MFA_CODE=$OPTARG
@@ -35,6 +51,10 @@ do
   esac
 done
 
+if [ -z "$MFA_CODE" ]; then
+  usage
+fi
+
 USERNAME=$(aws sts get-caller-identity | jq -r .Arn | rev | cut -f1 -d'/' | rev)
 MFA_DEVICE=$(aws iam list-mfa-devices --user-name "$USERNAME" | jq -r .MFADevices[0].SerialNumber)
 SESSION_TOKEN_JSON=$(aws sts get-session-token --serial-number "$MFA_DEVICE" --token-code "$MFA_CODE")
@@ -43,20 +63,19 @@ AWS_SECRET_ACCESS_KEY=$(echo "$SESSION_TOKEN_JSON" | jq -r .Credentials.SecretAc
 AWS_SESSION_TOKEN=$(echo "$SESSION_TOKEN_JSON" | jq -r .Credentials.SessionToken)
 AWS_SESSION_EXPIRATION=$(echo "$SESSION_TOKEN_JSON" | jq -r .Credentials.Expiration | awk -F':' -v OFS=':' '{ print $1, $2, $3$4 }')
 
-if [ "$EXPORT_TO_STDOUT" == 1 ];
-then
+if [ "$EXPORT_TO_STDOUT" == 1 ]; then
   echo "export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
   echo "export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
   echo "export AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN"
 else
-  echo "==> Storing MFA credentials in $DALMATIAN_MFA_CREDENTIALS_FILE"
+  log_info -l "Storing MFA credentials in $DALMATIAN_MFA_CREDENTIALS_FILE" -q "$QUIET_MODE"
   MFA_CREDENTIALS_JSON_STRING=$(
     jq -n \
-    --arg aws_access_key_id "$AWS_ACCESS_KEY_ID" \
-    --arg aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" \
-    --arg aws_session_token "$AWS_SESSION_TOKEN" \
-    --arg aws_session_expiration "$AWS_SESSION_EXPIRATION" \
-    '{
+      --arg aws_access_key_id "$AWS_ACCESS_KEY_ID" \
+      --arg aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" \
+      --arg aws_session_token "$AWS_SESSION_TOKEN" \
+      --arg aws_session_expiration "$AWS_SESSION_EXPIRATION" \
+      '{
       aws_access_key_id: $aws_access_key_id,
       aws_secret_access_key: $aws_secret_access_key,
       aws_session_token: $aws_session_token,

--- a/bin/aws/v2/account-init
+++ b/bin/aws/v2/account-init
@@ -86,8 +86,8 @@ then
     }'
   )
   log_info -l "External accounts require a Role to be added that can be assumed by the AWS Federated user account from the Main Dalmatian account" -q "$QUIET_MODE"
-  log_info -l "1. In the External Account (${AWS_ACCOUNT_ID:1}), create a Role named '$MAIN_DALMATIAN_ACCOUNT_ID-dalmatian-access', which has Administrator permissions" -q "$QUIET_MODE"
-  log_info -l "2. Add the following Trust Relationship policy to the role:" -q "$QUIET_MODE"
+  log_msg -l "1. In the External Account (${AWS_ACCOUNT_ID:1}), create a Role named '$MAIN_DALMATIAN_ACCOUNT_ID-dalmatian-access', which has Administrator permissions" -q "$QUIET_MODE"
+  log_msg -l "2. Add the following Trust Relationship policy to the role:" -q "$QUIET_MODE"
   echo "$EXTERNAL_ROLE_TRUST_RELATIONSHIP"
   if ! yes_no "Enter 'y' to continue:" "y"
   then

--- a/bin/cloudfront/v1/clear-cache
+++ b/bin/cloudfront/v1/clear-cache
@@ -54,7 +54,7 @@ then
   usage
 fi
 
-echo "==> Finding CloudFront distribution..."
+log_info -l "Finding CloudFront distribution..." -q "$QUIET_MODE"
 
 DISTRIBUTIONS=$(aws cloudfront list-distributions)
 DISTRIBUTION=$(echo "$DISTRIBUTIONS" | jq -r --arg origin "$INFRASTRUCTURE_NAME-$SERVICE_NAME-$ENVIRONMENT-default-origin" '.DistributionList.Items[] | select(.Origins.Items[].Id==$origin)')
@@ -62,7 +62,7 @@ DISTRIBUTION_ID=$(echo "$DISTRIBUTION" | jq -r '.Id')
 DISTRIBUTION_ALIAS=$(echo "$DISTRIBUTION" | jq -r '.Aliases.Items[0]')
 DISTRIBUTION_DOMAIN=$(echo "$DISTRIBUTION" | jq -r '.DomainName')
 
-echo "==> Running invalidation on distribution $DISTRIBUTION_ID ( $DISTRIBUTION_ALIAS, $DISTRIBUTION_DOMAIN ) ..."
+log_info -l "Running invalidation on distribution $DISTRIBUTION_ID ( $DISTRIBUTION_ALIAS, $DISTRIBUTION_DOMAIN ) ..." -q "$QUIET_MODE"
 
 DISTRIBUTION_INVALIDATION=$(aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths "$PATHS")
 DISTRIBUTION_INVALIDATION_ID=$(echo "$DISTRIBUTION_INVALIDATION" | jq -r '.Invalidation.Id')

--- a/bin/configure-commands/v1/login
+++ b/bin/configure-commands/v1/login
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+# exit on failures
+set -e
+set -o pipefail
+
+if [ -z "$APP_ROOT" ]; then
+  APP_ROOT="$( cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. && pwd -P)"
+fi
+
+if ! command -v log_info > /dev/null; then
+  for f in "$APP_ROOT"/lib/bash-functions/*; do
+    if [ -f "$f" ]; then
+      source "$f"
+      while IFS='' read -r function_name; do
+        export -f "${function_name?}"
+      done < <(grep "^function" "$f" | cut -d" " -f2)
+    fi
+  done
+fi
+
+QUIET_MODE="${QUIET_MODE:-0}"
+
 echo "Note: You must have a Dalmatian Admin account to use Dalmatian Tools"
 echo
 
@@ -13,7 +34,7 @@ if ! is_installed "brew"; then
       exit 1
     fi
   else
-    echo "Please install Homebrew before trying again"
+    err "Please install Homebrew before trying again"
     exit 1
   fi
 fi
@@ -50,8 +71,7 @@ then
   echo "    https://gpgtools.org/ is recommended for MacOS"
   exit 1
 fi
-echo "For added security, your credentials and MFA secret will be"
-echo "encrypted with GPG"
+log_info -l "For added security, your credentials and MFA secret will be encrypted with GPG" -q "$QUIET_MODE"
 echo ""
 read -rp "Email associated with GPG key: " GPG_ENCRYPT_EMAIL
 read -rp "AWS Access Key ID: " AWS_ACCESS_KEY_ID
@@ -62,11 +82,11 @@ echo "https://github.com/dxw/dalmatian-tools#why-am-i-seeing-oathtool-base32-dec
 read -rsp "AWS MFA Secret: " AWS_MFA_SECRET
 echo ""
 
-echo "==> Checking credentials..."
+log_info -l "Checking credentials..." -q "$QUIET_MODE"
 if [ ${#AWS_MFA_SECRET} -lt 7 ]
 then
-  echo "==> please enter your MFA secret not your generated MFA code"
-  echo "==> please see https://github.com/dxw/dalmatian-tools#why-am-i-seeing-oathtool-base32-decoding-failed-base32-string-is-invalid"
+  err "please enter your MFA secret not your generated MFA code"
+  err "please see https://github.com/dxw/dalmatian-tools#why-am-i-seeing-oathtool-base32-decoding-failed-base32-string-is-invalid"
   exit 1
 fi
 
@@ -79,9 +99,9 @@ USER_ID=$(echo "$CALLER_ID" | jq -r '.UserId')
 ACCOUNT_ID=$(echo "$CALLER_ID" | jq -r '.Account')
 USER_ARN=$(echo "$CALLER_ID" | jq -r '.Arn')
 
-echo "  User ID: $USER_ID"
-echo "  Account: $ACCOUNT_ID"
-echo "  Arn:     $USER_ARN"
+log_info -l "User ID: $USER_ID" -q "$QUIET_MODE"
+log_info -l "Account: $ACCOUNT_ID" -q "$QUIET_MODE"
+log_info -l "Arn:     $USER_ARN" -q "$QUIET_MODE"
 
 #echo "==> Checking access key age"
 #if ! "$APP_ROOT/bin/aws/key-age"
@@ -89,7 +109,7 @@ echo "  Arn:     $USER_ARN"
 #  exit 1
 #fi
 
-echo "==> Saving configuration settings in $DALMATIAN_CONFIG_FILE ..."
+log_info -l "Saving configuration settings in $DALMATIAN_CONFIG_FILE ..." -q "$QUIET_MODE"
 
 CONFIG_JSON_STRING=$(
   jq -n \
@@ -105,7 +125,7 @@ CONFIG_JSON_STRING=$(
 
 echo "$CONFIG_JSON_STRING" > "$DALMATIAN_CONFIG_FILE"
 
-echo "==> Attempting MFA..."
+log_info -l "Attempting MFA..." -q "$QUIET_MODE"
 
 MFA_CODE="$(oathtool --base32 --totp "$AWS_MFA_SECRET")"
 
@@ -121,9 +141,8 @@ export AWS_SECRET_ACCESS_KEY
 
 if "$APP_ROOT/bin/aws/v1/mfa" -m "$MFA_CODE"
 then
-  echo "==> Login success!"
-  echo "==> Storing credentials in $DALMATIAN_CREDENTIALS_FILE"
-
+  log_info -l "Login success!" -q "$QUIET_MODE"
+  log_info -l "Storing credentials in $DALMATIAN_CREDENTIALS_FILE" -q "$QUIET_MODE"
   CREDENTIALS_JSON_STRING=$(
     jq -n \
     --arg aws_access_key_id "$AWS_ACCESS_KEY_ID" \

--- a/bin/configure-commands/v1/login
+++ b/bin/configure-commands/v1/login
@@ -11,6 +11,7 @@ fi
 if ! command -v log_info > /dev/null; then
   for f in "$APP_ROOT"/lib/bash-functions/*; do
     if [ -f "$f" ]; then
+      # shellcheck disable=SC1090
       source "$f"
       while IFS='' read -r function_name; do
         export -f "${function_name?}"

--- a/bin/configure-commands/v2/setup
+++ b/bin/configure-commands/v2/setup
@@ -4,17 +4,17 @@
 set -e
 set -o pipefail
 
-log_info -l "----------------------------------------------------" -q "$QUIET_MODE"
-log_info -l "| To enable us to deploy the resources across      |" -q "$QUIET_MODE"
-log_info -l "| multiple AWS accounts, we will configure AWS SSO |" -q "$QUIET_MODE"
-log_info -l "| and store the required AWS profiles, and other   |" -q "$QUIET_MODE"
-log_info -l "| configuration within:                            |" -q "$QUIET_MODE"
-log_info -l "| \`\$HOME/.config/dalmatian\`                        |" -q "$QUIET_MODE"
-log_info -l "|                                                  |" -q "$QUIET_MODE"
-log_info -l "| This configuration will then be automatically    |" -q "$QUIET_MODE"
-log_info -l "| loaded and used when running other dalmatian     |" -q "$QUIET_MODE"
-log_info -l "| tools commands                                   |" -q "$QUIET_MODE"
-log_info -l "----------------------------------------------------" -q "$QUIET_MODE"
+log_msg -l "----------------------------------------------------" -q "$QUIET_MODE"
+log_msg -l "| To enable us to deploy the resources across      |" -q "$QUIET_MODE"
+log_msg -l "| multiple AWS accounts, we will configure AWS SSO |" -q "$QUIET_MODE"
+log_msg -l "| and store the required AWS profiles, and other   |" -q "$QUIET_MODE"
+log_msg -l "| configuration within:                            |" -q "$QUIET_MODE"
+log_msg -l "| \`\$HOME/.config/dalmatian\`                        |" -q "$QUIET_MODE"
+log_msg -l "|                                                  |" -q "$QUIET_MODE"
+log_msg -l "| This configuration will then be automatically    |" -q "$QUIET_MODE"
+log_msg -l "| loaded and used when running other dalmatian     |" -q "$QUIET_MODE"
+log_msg -l "| tools commands                                   |" -q "$QUIET_MODE"
+log_msg -l "----------------------------------------------------" -q "$QUIET_MODE"
 
 mkdir -p "$CONFIG_DIR"
 mkdir -p "$CONFIG_CACHE_DIR"
@@ -104,7 +104,7 @@ read_prompt_with_setup_default -p "AWS SSO Default administrative role name" -d 
 read_prompt_with_setup_default -p "AWS SSO Registration Scopes" -d "aws_sso.registration_scopes" -s
 
 log_info -l "-- Backend Configuration --" -q "$QUIET_MODE"
-log_info -l "Enter the S3 backend configuration parameters" -q "$QUIET_MODE"
+log_msg -l "Enter the S3 backend configuration parameters" -q "$QUIET_MODE"
 BACKEND_S3_BUCKET_NAME=$(read_prompt_with_setup_default -p "Bucket Name" -d "backend.s3.bucket_name")
 BACKEND_S3_BUCKET_REGION=$(read_prompt_with_setup_default -p "Bucket Region" -d "backend.s3.bucket_region")
 

--- a/bin/configure-commands/v2/update
+++ b/bin/configure-commands/v2/update
@@ -102,7 +102,7 @@ then
   # Ensure AWS Session Manager is up-to-date
   install_session_manager
 
-  log_info -l "Ensuring tfenv is configured ..."
+  log_info -l "Ensuring tfenv is configured ..." -q "$QUIET_MODE"
   $BREW_BIN link --overwrite tfenv
 
   "$APP_ROOT/bin/dalmatian" terraform-dependencies clone -I

--- a/bin/configure-commands/v2/version
+++ b/bin/configure-commands/v2/version
@@ -69,17 +69,17 @@ fi
 log_info -l "Dalmatian Tools $VERSION" -q "$QUIET_MODE"
 if [ "$VERSION" == "v1" ]
 then
-  log_info -l "The tooling available in v1 is to be used with infrastructure" -q "$QUIET_MODE"
-  log_info -l "launched with the dxw/dalmatian repo, which is private and internal" -q "$QUIET_MODE"
-  log_info -l "To use tooling for use with infrastructures deployed via dalmatian-tools," -q "$QUIET_MODE"
-  log_info -l "switch to 'v2' by running 'dalmatian version -v 2'" -q "$QUIET_MODE"
+  log_msg -l "The tooling available in v1 is to be used with infrastructure" -q "$QUIET_MODE"
+  log_msg -l "launched with the dxw/dalmatian repo, which is private and internal" -q "$QUIET_MODE"
+  log_msg -l "To use tooling for use with infrastructures deployed via dalmatian-tools," -q "$QUIET_MODE"
+  log_msg -l "switch to 'v2' by running 'dalmatian version -v 2'" -q "$QUIET_MODE"
 fi
 if [ "$VERSION" == "v2" ]
 then
   RELEASE=$(git -C "$APP_ROOT" describe --tags)
-  log_info -l "(Release: $RELEASE)"
-  log_info -l "The tooling available in v2 is to be used with infrastructures" -q "$QUIET_MODE"
-  log_info -l "deployed via dalmatian-tools" -q "$QUIET_MODE"
-  log_info -l "To use tooling for use with infrastructures launched with the dxw/dalmatian repo," -q "$QUIET_MODE"
-  log_info -l "switch to 'v1' by running 'dalmatian version -v 1'" -q "$QUIET_MODE"
+  log_info -l "(Release: $RELEASE)" -q "$QUIET_MODE"
+  log_msg -l "The tooling available in v2 is to be used with infrastructures" -q "$QUIET_MODE"
+  log_msg -l "deployed via dalmatian-tools" -q "$QUIET_MODE"
+  log_msg -l "To use tooling for use with infrastructures launched with the dxw/dalmatian repo," -q "$QUIET_MODE"
+  log_msg -l "switch to 'v1' by running 'dalmatian version -v 1'" -q "$QUIET_MODE"
 fi

--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -367,7 +367,7 @@ then
   AWS_MFA_SECRET=$(echo "$DALMATIAN_CREDENTIALS_JSON_STRING" | jq -r '.aws_mfa_secret')
   MFA_CODE="$(oathtool --base32 --totp "$AWS_MFA_SECRET")"
 
-  echo "==> Requesting new MFA credentials..."
+  log_info -l "Requesting new MFA credentials..." -q "$QUIET_MODE"
   "$APP_ROOT/bin/aws/$VERSION/mfa" -m "$MFA_CODE"
 
   if [ -n "$RUN_AWS_MFA" ]
@@ -407,7 +407,7 @@ fi
 # Update assume role credentials if needed
 if [ "$ASSUME_MAIN_ROLE_CONFIGURED" == "0" ]
 then
-  echo "==> Requesting 'Assume Role' credentials ..."
+  log_info -l "Requesting 'Assume Role' credentials ..." -q "$QUIET_MODE"
   ASSUME_ROLE_RESULT=$(
     aws sts assume-role \
     --role-arn "arn:aws:iam::$ACCOUNT_ID:role/$DALMATIAN_ROLE" \

--- a/bin/dalmatian-refresh-config
+++ b/bin/dalmatian-refresh-config
@@ -11,6 +11,7 @@ fi
 if ! command -v log_info > /dev/null; then
   for f in "$APP_ROOT"/lib/bash-functions/*; do
     if [ -f "$f" ]; then
+      # shellcheck disable=SC1090
       source "$f"
       while IFS='' read -r function_name; do
         export -f "${function_name?}"

--- a/bin/dalmatian-refresh-config
+++ b/bin/dalmatian-refresh-config
@@ -4,16 +4,33 @@
 set -e
 set -o pipefail
 
+if [ -z "$APP_ROOT" ]; then
+  APP_ROOT="$( cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd -P)"
+fi
+
+if ! command -v log_info > /dev/null; then
+  for f in "$APP_ROOT"/lib/bash-functions/*; do
+    if [ -f "$f" ]; then
+      source "$f"
+      while IFS='' read -r function_name; do
+        export -f "${function_name?}"
+      done < <(grep "^function" "$f" | cut -d" " -f2)
+    fi
+  done
+fi
+
+QUIET_MODE="${QUIET_MODE:-0}"
+
 SCRIPT_PATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
-echo "==> Finding Dalmatian config..."
+log_info -l "Finding Dalmatian config..." -q "$QUIET_MODE"
 CI_PIPELINE=$(aws codepipeline get-pipeline --name ci-terraform-build-pipeline)
 CI_BUILD_PROJECT_NAME=$(echo "$CI_PIPELINE" | jq -r '.pipeline.stages[] | select(.name == "Build") | .actions[] | select(.name == "Build-ci") | .configuration.ProjectName')
 
 BUILD_PROJECTS=$(aws codebuild batch-get-projects --names "$CI_BUILD_PROJECT_NAME")
 DALMATIAN_CONFIG_REPO=$(echo "$BUILD_PROJECTS" | jq -r '.projects[0].environment.environmentVariables[] | select(.name == "dalmatian_config_repo") | .value')
 
-echo "==> Fetching Dalmatian config..."
+log_info -l "Fetching Dalmatian config..." -q "$QUIET_MODE"
 rm -rf "$SCRIPT_PATH/tmp/dalmatian-config"
 
 set +e

--- a/bin/ec2/v2/port-forward
+++ b/bin/ec2/v2/port-forward
@@ -31,9 +31,9 @@ fi
 if ! command -v session-manager-plugin > /dev/null
 then
   err "This script requires the \`session-manager-plugin\` to be installed"
-  log_info -l "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" -q "$QUIET_MODE"
-  log_info -l "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:" -q "$QUIET_MODE"
-  log_info -l "softwareupdate --install-rosetta" -q "$QUIET_MODE"
+  log_msg -l "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" -q "$QUIET_MODE"
+  log_msg -l "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:" -q "$QUIET_MODE"
+  log_msg -l "softwareupdate --install-rosetta" -q "$QUIET_MODE"
   exit 1
 fi
 

--- a/bin/ecs/v1/ec2-access
+++ b/bin/ecs/v1/ec2-access
@@ -25,10 +25,10 @@ fi
 
 if ! command -v session-manager-plugin > /dev/null
 then
-  echo "This script requires the \`session-manager-plugin\` to be installed:"
-  echo "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-  echo "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:"
-  echo "softwareupdate --install-rosetta"
+  err "This script requires the \`session-manager-plugin\` to be installed"
+  log_info -l "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" -q "$QUIET_MODE"
+  log_info -l "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:" -q "$QUIET_MODE"
+  log_info -l "softwareupdate --install-rosetta" -q "$QUIET_MODE"
   exit 1
 fi
 
@@ -63,7 +63,7 @@ then
   usage
 fi
 
-echo "==> Finding ECS instance..."
+log_info -l "Finding ECS instance..." -q "$QUIET_MODE"
 INSTANCES=$(aws ec2 describe-instances --filters Name=instance-state-code,Values=16 Name=tag:Name,Values="$INFRASTRUCTURE_NAME-$ENVIRONMENT*")
 
 AVAILABLE_INSTANCES=$(echo "$INSTANCES" | jq -r '.Reservations[].Instances[] | (.InstanceId) + " | " + (.Tags[] | select(.Key == "Name") | .Value) + " | " + (.LaunchTime)')
@@ -90,6 +90,6 @@ else
   fi
 fi
 
-echo "==> Connecting to '$INSTANCE_NAME' (id: $INSTANCE_ID)..."
+log_info -l "Connecting to '$INSTANCE_NAME' (id: $INSTANCE_ID)..." -q "$QUIET_MODE"
 
 aws ssm start-session --target "$INSTANCE_ID"

--- a/bin/ecs/v1/efs-restore
+++ b/bin/ecs/v1/efs-restore
@@ -60,7 +60,7 @@ fi
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
 # Retrieve the list of recovery points for the file system
-echo "Retrieving recovery points for the file system..."
+log_info -l "Retrieving recovery points for the file system..." -q "$QUIET_MODE"
 RECOVERY_POINTS=$(aws backup list-recovery-points-by-resource --resource-arn "arn:aws:elasticfilesystem:eu-west-2:${ACCOUNT_ID}:file-system/${FILE_SYSTEM_ID}" --query "RecoveryPoints[].RecoveryPointArn" --output json)
 
 if [[ -z "$RECOVERY_POINTS" ]]; then
@@ -75,11 +75,11 @@ if [[ "$LATEST_RECOVERY_POINT_ARN" == "null" ]]; then
   err "No latest recovery point found for the specified file system."
   exit 1
 else
-  echo "Latest Recovery Point Arn >>> $LATEST_RECOVERY_POINT_ARN"
+  log_info -l "Latest Recovery Point Arn >>> $LATEST_RECOVERY_POINT_ARN" -q "$QUIET_MODE"
 fi
 
 # Modify the metadata JSON file with the specific file or directory to restore
-echo "Modifying the metadata JSON file"
+log_info -l "Modifying the metadata JSON file" -q "$QUIET_MODE"
 METADATA_FILE="/tmp/$(date +%s).metadata.json"
 
 # Create a temporary metadata file based on the template and replace placeholders with actual values
@@ -87,7 +87,7 @@ touch "$METADATA_FILE"
 echo "{\"file-system-id\": \"$FILE_SYSTEM_ID\", \"itemsToRestore\": \"[\\\"$FILE_PATH\\\"]\", \"newFileSystem\": \"false\"}" > "$METADATA_FILE"
 
 # Restore the file using the retrieved file system ID and metadata JSON file
-echo "Starting backup restore job"
+log_info -l "Starting backup restore job" -q "$QUIET_MODE"
 aws backup start-restore-job --no-cli-pager --recovery-point-arn "$LATEST_RECOVERY_POINT_ARN" --metadata "file://${METADATA_FILE}" --resource-type "EFS" --iam-role-arn "arn:aws:iam::${ACCOUNT_ID}:role/service-role/AWSBackupDefaultServiceRole"
 
 # Remove the temporary metadata file

--- a/bin/ecs/v1/file-download
+++ b/bin/ecs/v1/file-download
@@ -27,10 +27,10 @@ fi
 
 if ! command -v session-manager-plugin > /dev/null
 then
-  echo "This script requires the \`session-manager-plugin\` to be installed:"
-  echo "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-  echo "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:"
-  echo "softwareupdate --install-rosetta"
+  err "This script requires the \`session-manager-plugin\` to be installed"
+  log_info -l "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" -q "$QUIET_MODE"
+  log_info -l "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:" -q "$QUIET_MODE"
+  log_info -l "softwareupdate --install-rosetta" -q "$QUIET_MODE"
   exit 1
 fi
 
@@ -78,7 +78,7 @@ fi
 BUCKET_NAME="$INFRASTRUCTURE_NAME-ecs-$ENVIRONMENT-dalmatian-transfer"
 PREFIX_DIR="$(gdate +%s)"
 
-echo "==> Copying to $BUCKET_NAME S3 bucket ..."
+log_info -l "Copying to $BUCKET_NAME S3 bucket ..." -q "$QUIET_MODE"
 
 if [ "$RECURSIVE" == 1 ];
 then
@@ -92,13 +92,13 @@ else
 fi
 
 
-echo "==> Finding ECS instance..."
+log_info -l "Finding ECS instance..." -q "$QUIET_MODE"
 
 INSTANCES=$(aws ec2 describe-instances --filters Name=instance-state-code,Values=16 Name=tag:Name,Values="$INFRASTRUCTURE_NAME-$ENVIRONMENT*")
 INSTANCE_ID=${INSTANCE_ID:-$(echo "$INSTANCES" | jq -r '.Reservations[0].Instances[0].InstanceId' )}
 INSTANCE_NAME=$(echo "$INSTANCES" | jq -r '.Reservations[0].Instances[0].Tags[] | select(.Key == "Name") | .Value')
 
-echo "==> uploading from '$INSTANCE_NAME' (id: $INSTANCE_ID) to S3.."
+log_info -l "uploading from '$INSTANCE_NAME' (id: $INSTANCE_ID) to S3.." -q "$QUIET_MODE"
 
 aws ssm start-session \
   --target "$INSTANCE_ID" \
@@ -106,11 +106,11 @@ aws ssm start-session \
   --parameters "S3Target=s3://$BUCKET_NAME/$PREFIX_DIR/$(basename "$SOURCE"),Source=$SOURCE,Recursive=$SSM_S3_RECURSIVE"
 
 
-echo "==> Downloading from S3 bucket"
+log_info -l "Downloading from S3 bucket" -q "$QUIET_MODE"
 # shellcheck disable=2086
 aws s3 cp s3://"$BUCKET_NAME"/"$PREFIX_DIR"/"$(basename "$SOURCE")" "$LOCAL_TARGET" $S3_RECURSIVE
-echo "==> Removing from S3 bucket ..."
+log_info -l "Removing from S3 bucket ..." -q "$QUIET_MODE"
 # shellcheck disable=2086
 aws s3 rm s3://"$BUCKET_NAME"/"$PREFIX_DIR"/"$(basename "$SOURCE")" $S3_RECURSIVE
 
-echo "Success!"
+log_info -l "Success!" -q "$QUIET_MODE"

--- a/bin/ecs/v1/file-upload
+++ b/bin/ecs/v1/file-upload
@@ -27,10 +27,10 @@ fi
 
 if ! command -v session-manager-plugin > /dev/null
 then
-  echo "This script requires the \`session-manager-plugin\` to be installed:"
-  echo "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-  echo "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:"
-  echo "softwareupdate --install-rosetta"
+  err "This script requires the \`session-manager-plugin\` to be installed"
+  log_info -l "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" -q "$QUIET_MODE"
+  log_info -l "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:" -q "$QUIET_MODE"
+  log_info -l "softwareupdate --install-rosetta" -q "$QUIET_MODE"
   exit 1
 fi
 
@@ -78,7 +78,7 @@ fi
 BUCKET_NAME="$INFRASTRUCTURE_NAME-ecs-$ENVIRONMENT-dalmatian-transfer"
 PREFIX_DIR="$(gdate +%s)"
 
-echo "==> Copying to $BUCKET_NAME S3 bucket ..."
+log_info -l "Copying to $BUCKET_NAME S3 bucket ..." -q "$QUIET_MODE"
 
 if [ "$RECURSIVE" == 1 ];
 then
@@ -96,18 +96,18 @@ aws s3 cp "$SOURCE" s3://"$BUCKET_NAME"/"$PREFIX_DIR"/"$(basename "$SOURCE")" $S
 
 ECS_INSTANCE_ID=${ECS_INSTANCE_ID:-$(pick_ecs_instance -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT")}
 
-echo "==> Downloading from S3 to $ECS_INSTANCE_ID..."
+log_info -l "Downloading from S3 to $ECS_INSTANCE_ID..." -q "$QUIET_MODE"
 
-echo "==> s3://$BUCKET_NAME/$PREFIX_DIR/$(basename "$SOURCE") -> $HOST_TARGET"
+log_info -l "s3://$BUCKET_NAME/$PREFIX_DIR/$(basename "$SOURCE") -> $HOST_TARGET" -q "$QUIET_MODE"
 
 aws ssm start-session \
   --target "$ECS_INSTANCE_ID" \
   --document-name "$INFRASTRUCTURE_NAME-$ENVIRONMENT-s3-download" \
   --parameters "Source=s3://$BUCKET_NAME/$PREFIX_DIR/$(basename "$SOURCE"),HostTarget=$HOST_TARGET,Recursive=$SSM_S3_RECURSIVE"
 
-echo "==> Removing from S3 bucket ..."
+log_info -l "Removing from S3 bucket ..." -q "$QUIET_MODE"
 
 # shellcheck disable=2086
 aws s3 rm s3://"$BUCKET_NAME"/"$PREFIX_DIR"/"$(basename "$SOURCE")" $S3_RECURSIVE
 
-echo "Success!"
+log_info -l "Success!" -q "$QUIET_MODE"

--- a/bin/ecs/v1/instance-refresh
+++ b/bin/ecs/v1/instance-refresh
@@ -43,7 +43,7 @@ then
   usage
 fi
 
-#echo "==> Refreshing instances on $INFRASTRUCTURE_NAME $ENVIRONMENT..."
+log_info -l "Refreshing instances on $INFRASTRUCTURE_NAME $ENVIRONMENT..." -q "$QUIET_MODE"
 AUTO_SCALING_GROUP_NAME=$(aws autoscaling describe-auto-scaling-groups | jq -r --arg i "$INFRASTRUCTURE_NAME" --arg e "$ENVIRONMENT" '.AutoScalingGroups[] | select(.AutoScalingGroupName | test("asg-ecs-\($i)-\($e).*")) | .AutoScalingGroupName')
 INSTANCE_REFRESH_ID=$(aws autoscaling start-instance-refresh --auto-scaling-group-name "$AUTO_SCALING_GROUP_NAME" | jq -r '.InstanceRefreshId')
 
@@ -60,11 +60,11 @@ do
   then
     if [ "$NEW_STATUS_REASON" != "null" ]
     then
-      echo "$NEW_STATUS_REASON"
+      log_info -l "$NEW_STATUS_REASON" -q "$QUIET_MODE"
     fi
     STATUS_REASON="$NEW_STATUS_REASON"
   fi
-  echo "Status: $STATUS, Percent Complete: $PERCENT_COMPLETE, Instances to update: $INSTANCES_TO_UPDATE"
+  log_info -l "Status: $STATUS, Percent Complete: $PERCENT_COMPLETE, Instances to update: $INSTANCES_TO_UPDATE" -q "$QUIET_MODE"
   if [ "$STATUS" != "Successful" ]
   then
     sleep 30

--- a/bin/ecs/v2/ec2-access
+++ b/bin/ecs/v2/ec2-access
@@ -26,9 +26,9 @@ fi
 if ! command -v session-manager-plugin > /dev/null
 then
   err "This script requires the \`session-manager-plugin\` to be installed"
-  log_info -l "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" -q "$QUIET_MODE"
-  log_info -l "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:" -q "$QUIET_MODE"
-  log_info -l "softwareupdate --install-rosetta" -q "$QUIET_MODE"
+  log_msg -l "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" -q "$QUIET_MODE"
+  log_msg -l "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:" -q "$QUIET_MODE"
+  log_msg -l "softwareupdate --install-rosetta" -q "$QUIET_MODE"
   exit 1
 fi
 
@@ -109,7 +109,7 @@ else
   if [ -z "$INSTANCE_NAME" ];
   then
     err "Instance ID '$INSTANCE_ID' was not found"
-    log_info -l "Available instances:" -q "$QUIET_MODE"
+    log_msg -l "Available instances:" -q "$QUIET_MODE"
     echo "$AVAILABLE_INSTANCES"
     exit 1
   fi

--- a/bin/elasticache/v1/reboot
+++ b/bin/elasticache/v1/reboot
@@ -66,13 +66,13 @@ do
     NODES=$(echo "$CLUSTERS" |  jq --arg "cluster_id" "$CLUSTER" -r '.CacheClusters[] | select(.CacheClusterId == $cluster_id).CacheNodes[].CacheNodeId')
     if [[ -n "$VERBOSE" ]];
     then
-      echo "Rebooting node(s) $(echo "$NODES" | tr ' ' ',') in Elasticache cluster $NICE_NAME (id: $CLUSTER)..."
+      log_info -l "Rebooting node(s) $(echo "$NODES" | tr ' ' ',') in Elasticache cluster $NICE_NAME (id: $CLUSTER)..." -q "$QUIET_MODE"
     else
-      echo "Rebooting all nodes in Elasticache cluster $NICE_NAME..."
+      log_info -l "Rebooting all nodes in Elasticache cluster $NICE_NAME..." -q "$QUIET_MODE"
     fi
     aws elasticache reboot-cache-cluster --cache-cluster-id "$CLUSTER" --cache-node-ids-to-reboot "$NODES"
   elif [[ -n "$VERBOSE" ]];
   then
-    echo "Skipping $NICE_NAME."
+    log_info -l "Skipping $NICE_NAME." -q "$QUIET_MODE"
   fi
 done

--- a/bin/rds/v1/count-sql-backups
+++ b/bin/rds/v1/count-sql-backups
@@ -62,7 +62,7 @@ RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
 S3_BUCKET_NAME="$INFRASTRUCTURE_NAME-$RDS_IDENTIFIER-sql-backup"
 
-echo "==> Counting SQL backups in $INFRASTRUCTURE_NAME $RDS_NAME $ENVIRONMENT..."
+log_info -l "Counting SQL backups in $INFRASTRUCTURE_NAME $RDS_NAME $ENVIRONMENT..." -q "$QUIET_MODE"
 
 aws s3api list-objects-v2 \
   --bucket "$S3_BUCKET_NAME" \

--- a/bin/rds/v1/create-database
+++ b/bin/rds/v1/create-database
@@ -72,7 +72,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -84,7 +84,7 @@ RDS_ROOT_PASSWORD=$(
     | jq -r .Parameters[0].Value
 )
 
-echo "==> Getting RDS info..."
+log_info -l "Getting RDS info..." -q "$QUIET_MODE"
 
 RDS_INFO=$(
   aws rds describe-db-instances \
@@ -94,19 +94,19 @@ RDS_ENGINE=$(echo "$RDS_INFO" | jq -r .DBInstances[0].Engine)
 RDS_ROOT_USERNAME=$(echo "$RDS_INFO" | jq -r .DBInstances[0].MasterUsername)
 RDS_VPC=$(echo "$RDS_INFO" | jq -r .DBInstances[0].DBSubnetGroup.VpcId)
 
-echo "Engine: $RDS_ENGINE"
-echo "Root username: $RDS_ROOT_USERNAME"
-echo "VPC ID: $RDS_VPC"
+log_msg -l "Engine: $RDS_ENGINE" -q "$QUIET_MODE"
+log_msg -l "Root username: $RDS_ROOT_USERNAME" -q "$QUIET_MODE"
+log_msg -l "VPC ID: $RDS_VPC" -q "$QUIET_MODE"
 
 ECS_INSTANCE_ID=${ECS_INSTANCE_ID:-$(pick_ecs_instance -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT")}
 
-echo "ECS instance ID: $ECS_INSTANCE_ID"
+log_msg -l "ECS instance ID: $ECS_INSTANCE_ID" -q "$QUIET_MODE"
 
-echo "==> Creating database..."
+log_info -l "Creating database..." -q "$QUIET_MODE"
 
 aws ssm start-session \
   --target "$ECS_INSTANCE_ID" \
   --document-name "$RDS_IDENTIFIER-rds-db-creation" \
   --parameters "RootPassword=$RDS_ROOT_PASSWORD,NewDbName=$DB_NAME,NewUserName=$USER_NAME,NewUserPassword=$USER_PASSWORD"
 
-echo "Success!"
+log_info -l "Success!" -q "$QUIET_MODE"

--- a/bin/rds/v1/download-sql-backup
+++ b/bin/rds/v1/download-sql-backup
@@ -64,7 +64,7 @@ RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 S3_BUCKET_NAME="$INFRASTRUCTURE_NAME-$RDS_IDENTIFIER-sql-backup"
 TODAY=$(gdate +%Y-%m-%d)
 
-echo "==> Listing SQL backups in $INFRASTRUCTURE_NAME $RDS_NAME $ENVIRONMENT..."
+log_info -l "Listing SQL backups in $INFRASTRUCTURE_NAME $RDS_NAME $ENVIRONMENT..." -q "$QUIET_MODE"
 
 if [ -z "$DATE" ]
 then
@@ -78,11 +78,11 @@ OBJECTS="$(aws s3api list-objects-v2 \
 
 BACKUP_COUNT="$(echo "$OBJECTS" | jq -r 'length')"
 
-echo "Found $BACKUP_COUNT backups from $DATE"
+log_info -l "Found $BACKUP_COUNT backups from $DATE" -q "$QUIET_MODE"
 
 if [ "$BACKUP_COUNT" -lt 1 ];
 then
-  echo "Please specify a different date."
+  err "Please specify a different date."
   exit 1
 fi
 
@@ -110,9 +110,8 @@ then
   OUTPUT_FILE_PATH="$HOME/Downloads/$SQL_FILE_NAME"
 fi
 
-echo "[i] You've chosen option number $n: '$SQL_FILE_NAME'"
-echo
+log_info -l "You've chosen option number $n: '$SQL_FILE_NAME'" -q "$QUIET_MODE"
 
-echo "==> Starting download of $SQL_FILE_NAME from s3 bucket $S3_BUCKET_NAME..."
+log_info -l "Starting download of $SQL_FILE_NAME from s3 bucket $S3_BUCKET_NAME..." -q "$QUIET_MODE"
 
 aws s3 cp "s3://$S3_BUCKET_NAME/$SQL_FILE_NAME" "$OUTPUT_FILE_PATH"

--- a/bin/rds/v1/export-dump
+++ b/bin/rds/v1/export-dump
@@ -76,7 +76,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -88,7 +88,7 @@ RDS_ROOT_PASSWORD=$(
     | jq -r .Parameters[0].Value
 )
 
-echo "==> Getting RDS info..."
+log_info -l "Getting RDS info..." -q "$QUIET_MODE"
 
 RDS_INFO=$(
   aws rds describe-db-instances \
@@ -113,15 +113,15 @@ aws ssm start-session \
   --document-name "$RDS_IDENTIFIER-rds-sql-dump" \
   --parameters "RootPassword=$RDS_ROOT_PASSWORD,DatabaseName=$DATABASE_NAME"
 
-echo "==> Export complete"
+log_info -l "Export complete" -q "$QUIET_MODE"
 
 SQL_FILE_NAME="$DATABASE_NAME-$ENVIRONMENT-sql-export.sql"
 S3_BUCKET_NAME="$INFRASTRUCTURE_NAME-ecs-$ENVIRONMENT-dalmatian-transfer"
 
-echo "==> Starting download of $SQL_FILE_NAME from s3 bucket $S3_BUCKET_NAME..."
+log_info -l "Starting download of $SQL_FILE_NAME from s3 bucket $S3_BUCKET_NAME..." -q "$QUIET_MODE"
 
 aws s3 cp "s3://$S3_BUCKET_NAME/db_exports/$SQL_FILE_NAME" "$OUTPUT_FILE_PATH"
 
-echo "==> Deleting sql file from S3 ..."
+log_info -l "Deleting sql file from S3 ..." -q "$QUIET_MODE"
 
 aws s3 rm "s3://$S3_BUCKET_NAME/db_exports/$SQL_FILE_NAME"

--- a/bin/rds/v1/get-root-password
+++ b/bin/rds/v1/get-root-password
@@ -52,7 +52,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -64,7 +64,7 @@ RDS_ROOT_PASSWORD=$(
     | jq -r .Parameters[0].Value
 )
 
-echo "==> Getting RDS info..."
+log_info -l "Getting RDS info..." -q "$QUIET_MODE"
 
 RDS_INFO=$(
   aws rds describe-db-instances \

--- a/bin/rds/v1/import-dump
+++ b/bin/rds/v1/import-dump
@@ -75,7 +75,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -87,7 +87,7 @@ RDS_ROOT_PASSWORD=$(
     | jq -r .Parameters[0].Value
 )
 
-echo "==> Getting RDS info..."
+log_info -l "Getting RDS info..." -q "$QUIET_MODE"
 
 RDS_INFO=$(
   aws rds describe-db-instances \
@@ -97,17 +97,17 @@ RDS_ENGINE=$(echo "$RDS_INFO" | jq -r .DBInstances[0].Engine)
 RDS_ROOT_USERNAME=$(echo "$RDS_INFO" | jq -r .DBInstances[0].MasterUsername)
 RDS_VPC=$(echo "$RDS_INFO" | jq -r .DBInstances[0].DBSubnetGroup.VpcId)
 
-echo "Engine: $RDS_ENGINE"
-echo "Root username: $RDS_ROOT_USERNAME"
-echo "VPC ID: $RDS_VPC"
+log_msg -l "Engine: $RDS_ENGINE" -q "$QUIET_MODE"
+log_msg -l "Root username: $RDS_ROOT_USERNAME" -q "$QUIET_MODE"
+log_msg -l "VPC ID: $RDS_VPC" -q "$QUIET_MODE"
 
 ECS_INSTANCE_ID=${ECS_INSTANCE_ID:-$(pick_ecs_instance -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT")}
 
-echo "ECS instance ID: $ECS_INSTANCE_ID"
+log_msg -l "ECS instance ID: $ECS_INSTANCE_ID" -q "$QUIET_MODE"
 
 if [ ! -f "$DB_DUMP_FILE" ];
 then
-    echo "$DB_DUMP_FILE not found ..."
+    err "$DB_DUMP_FILE not found ..."
     exit 1
 fi
 
@@ -122,38 +122,38 @@ then
   DB_DUMP_FILE="$OUTPUT_PATH/$DB_DUMP_FILE"
 fi
 
-echo "--------------------------------------------------"
-echo "The RDS:"
-echo "  $RDS_IDENTIFIER"
-echo "in the infrastructure:"
-echo "  $INFRASTRUCTURE_NAME"
-echo "in environment:"
-echo "  $ENVIRONMENT"
-echo "will have the database:"
-echo "  $DATABASE_NAME"
-echo "overwritten with the file:"
-echo "  $DB_DUMP_FILE"
-echo "--------------------------------------------------"
-echo ""
-echo "Are you sure?"
-echo ""
+log_msg -l "--------------------------------------------------" -q "$QUIET_MODE"
+log_msg -l "The RDS:" -q "$QUIET_MODE"
+log_msg -l "  $RDS_IDENTIFIER" -q "$QUIET_MODE"
+log_msg -l "in the infrastructure:" -q "$QUIET_MODE"
+log_msg -l "  $INFRASTRUCTURE_NAME" -q "$QUIET_MODE"
+log_msg -l "in environment:" -q "$QUIET_MODE"
+log_msg -l "  $ENVIRONMENT" -q "$QUIET_MODE"
+log_msg -l "will have the database:" -q "$QUIET_MODE"
+log_msg -l "  $DATABASE_NAME" -q "$QUIET_MODE"
+log_msg -l "overwritten with the file:" -q "$QUIET_MODE"
+log_msg -l "  $DB_DUMP_FILE" -q "$QUIET_MODE"
+log_msg -l "--------------------------------------------------" -q "$QUIET_MODE"
+log_msg -l "" -q "$QUIET_MODE"
+log_msg -l "Are you sure?" -q "$QUIET_MODE"
+log_msg -l "" -q "$QUIET_MODE"
 
-echo "Continue (Yes/No)"
+log_msg -l "Continue (Yes/No)" -q "$QUIET_MODE"
 read -r -p " > " choice
 case "$choice" in
-  Yes ) echo "==> Importing ...";;
+  Yes ) log_info -l "Importing ..." -q "$QUIET_MODE";;
   * ) err "You must specify 'Yes' to continue. The import has been cancelled."
     exit 1
     ;;
 esac
 
-echo "Uploading $DB_DUMP_FILE ..."
+log_info -l "Uploading $DB_DUMP_FILE ..." -q "$QUIET_MODE"
 
 "$APP_ROOT/bin/ecs/v1/file-upload" -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT" -s "$DB_DUMP_FILE" -t "/tmp/$(basename "$DB_DUMP_FILE")" -I "$ECS_INSTANCE_ID"
 
-echo "==> Uploading complete!"
+log_info -l "Uploading complete!" -q "$QUIET_MODE"
 
-echo "==> Starting import of $RDS_ENGINE $DB_DUMP_FILE file into $RDS_IDENTIFIER..."
+log_info -l "Starting import of $RDS_ENGINE $DB_DUMP_FILE file into $RDS_IDENTIFIER..." -q "$QUIET_MODE"
 
 aws ssm start-session \
   --target "$ECS_INSTANCE_ID" \

--- a/bin/rds/v1/list-databases
+++ b/bin/rds/v1/list-databases
@@ -53,7 +53,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -65,7 +65,7 @@ RDS_ROOT_PASSWORD=$(
     | jq -r .Parameters[0].Value
 )
 
-echo "==> Getting RDS info..."
+log_info -l "Getting RDS info..." -q "$QUIET_MODE"
 
 RDS_INFO=$(
   aws rds describe-db-instances \
@@ -73,7 +73,7 @@ RDS_INFO=$(
 )
 RDS_VPC=$(echo "$RDS_INFO" | jq -r .DBInstances[0].DBSubnetGroup.VpcId)
 
-echo "==> Finding ECS instance..."
+log_info -l "Finding ECS instance..." -q "$QUIET_MODE"
 
 ECS_INSTANCES=$(
   aws ec2 describe-instances \
@@ -84,13 +84,13 @@ ECS_INSTANCE_ID=$(
     | jq -r .Reservations[0].Instances[0].InstanceId
 )
 
-echo "ECS instance ID: $ECS_INSTANCE_ID"
+log_info -l "ECS instance ID: $ECS_INSTANCE_ID" -q "$QUIET_MODE"
 
-echo "==> Listing databases..."
+log_info -l "Listing databases..." -q "$QUIET_MODE"
 
 aws ssm start-session \
   --target "$ECS_INSTANCE_ID" \
   --document-name "$RDS_IDENTIFIER-rds-db-list" \
   --parameters "RootPassword=$RDS_ROOT_PASSWORD"
 
-echo "Success!"
+log_info -l "Success!" -q "$QUIET_MODE"

--- a/bin/rds/v1/list-instances
+++ b/bin/rds/v1/list-instances
@@ -43,7 +43,7 @@ then
   usage
 fi
 
-echo "==> Getting RDS instances in $INFRASTRUCTURE_NAME $ENVIRONMENT..."
+log_info -l "Getting RDS instances in $INFRASTRUCTURE_NAME $ENVIRONMENT..." -q "$QUIET_MODE"
 
 RDS_IDENTIFIER_SEARCH="${INFRASTRUCTURE_NAME//-/}.*${ENVIRONMENT//-/}"
 

--- a/bin/rds/v1/set-root-password
+++ b/bin/rds/v1/set-root-password
@@ -57,7 +57,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Setting RDS root password in Parameter Store..."
+log_info -l "Setting RDS root password in Parameter Store..." -q "$QUIET_MODE"
 
 aws ssm put-parameter \
    --name "/$INFRASTRUCTURE_NAME/$RDS_IDENTIFIER-rds/password" \
@@ -66,7 +66,7 @@ aws ssm put-parameter \
    --key-id "alias/$INFRASTRUCTURE_NAME-$RDS_NAME-rds-$ENVIRONMENT-rds-values-ssm" \
    --overwrite
 
-echo "==> Parameter store value set"
+log_info -l "Parameter store value set" -q "$QUIET_MODE"
 echo "==> For this change to take effect, run the following from dalmatian core to deploy:"
 echo ""
 echo "    ./scripts/bin/deploy -i $INFRASTRUCTURE_NAME -e $ENVIRONMENT -S hosted-zone,vpn-customer-gateway,ecs,ecs-services,elasticache-cluster,shared-loadbalancer,waf"

--- a/bin/rds/v1/shell
+++ b/bin/rds/v1/shell
@@ -57,7 +57,7 @@ fi
 
 if [ -n "$LIST" ];
 then
-  echo "==> Finding ECS instances..."
+  log_info -l "Finding ECS instances..." -q "$QUIET_MODE"
   INSTANCES=$(aws ec2 describe-instances --filters Name=instance-state-code,Values=16 Name=tag:Name,Values="$INFRASTRUCTURE_NAME-$ENVIRONMENT*")
 
   AVAILABLE_INSTANCES=$(echo "$INSTANCES" | jq -r '.Reservations[].Instances[] | (.InstanceId) + " | " + (.Tags[] | select(.Key == "Name") | .Value) + " | " + (.LaunchTime)')
@@ -70,7 +70,7 @@ fi
 # need to remove them here to get the correct identifier.
 RDS_IDENTIFIER="${INFRASTRUCTURE_NAME//-/}${RDS_NAME//-/}${ENVIRONMENT//-/}"
 
-echo "==> Retrieving RDS root password from Parameter Store..."
+log_info -l "Retrieving RDS root password from Parameter Store..." -q "$QUIET_MODE"
 
 RDS_ROOT_PASSWORD_PARAMETER=$(
   aws ssm get-parameters \
@@ -82,7 +82,7 @@ RDS_ROOT_PASSWORD=$(
     | jq -r .Parameters[0].Value
 )
 
-echo "==> Getting RDS info..."
+log_info -l "Getting RDS info..." -q "$QUIET_MODE"
 
 RDS_INFO=$(
   aws rds describe-db-instances \
@@ -92,15 +92,15 @@ RDS_ENGINE=$(echo "$RDS_INFO" | jq -r .DBInstances[0].Engine)
 RDS_ROOT_USERNAME=$(echo "$RDS_INFO" | jq -r .DBInstances[0].MasterUsername)
 RDS_VPC=$(echo "$RDS_INFO" | jq -r .DBInstances[0].DBSubnetGroup.VpcId)
 
-echo "Engine: $RDS_ENGINE"
-echo "Root username: $RDS_ROOT_USERNAME"
-echo "VPC ID: $RDS_VPC"
+log_info -l "Engine: $RDS_ENGINE" -q "$QUIET_MODE"
+log_info -l "Root username: $RDS_ROOT_USERNAME" -q "$QUIET_MODE"
+log_info -l "VPC ID: $RDS_VPC" -q "$QUIET_MODE"
 
 ECS_INSTANCE_ID=${ECS_INSTANCE_ID:-$(pick_ecs_instance -i "$INFRASTRUCTURE_NAME" -e "$ENVIRONMENT")}
 
-echo "ECS instance ID: $ECS_INSTANCE_ID"
+log_info -l "ECS instance ID: $ECS_INSTANCE_ID" -q "$QUIET_MODE"
 
-echo "==> Starting $RDS_ENGINE session on $RDS_IDENTIFIER..."
+log_info -l "Starting $RDS_ENGINE session on $RDS_IDENTIFIER..." -q "$QUIET_MODE"
 
 aws ssm start-session \
   --target "$ECS_INSTANCE_ID" \

--- a/bin/rds/v1/start-sql-backup-to-s3
+++ b/bin/rds/v1/start-sql-backup-to-s3
@@ -63,4 +63,4 @@ ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
 # run the backup task
 aws ecs run-task --no-cli-pager --cluster "$CLUSTER_NAME" --task-definition "arn:aws:ecs:eu-west-2:$ACCOUNT_ID:task-definition/$TASK_NAME"
-echo "==> Started backup task $TASK_NAME for RDS instance $RDS_IDENTIFIER"
+log_info -l "Started backup task $TASK_NAME for RDS instance $RDS_IDENTIFIER" -q "$QUIET_MODE"

--- a/bin/s3/v2/list-bucket-properties
+++ b/bin/s3/v2/list-bucket-properties
@@ -67,8 +67,8 @@ fi
 
 while IFS='' read -r BUCKET
 do
-  echo "----------------------------------"
-  echo "$BUCKET"
+  log_msg -l "----------------------------------" -q "$QUIET_MODE"
+  log_msg -l "$BUCKET" -q "$QUIET_MODE"
   BUCKETS_ACL="$(
     "$APP_ROOT/bin/dalmatian" aws run-command \
       -p "$PROFILE" \
@@ -119,7 +119,7 @@ do
   then
     BLOCKS_PUBLIC_ACCESS_CHECK="✅"
   fi
-  log_info -l "Other ACLs: $OTHER_ACLS_COUNT $OTHER_ACLS_CHECK" -q "$QUIET_MODE"
-  log_info -l "Blocks public access: $BLOCKS_PUBLIC_ACCESS_CHECK" -q "$QUIET_MODE"
-  log_info -l "Bucket owner Full Control: $BUCKET_OWNER_FULL_CONTROL_CHECK" -q "$QUIET_MODE"
+  log_msg -l "Other ACLs: $OTHER_ACLS_COUNT $OTHER_ACLS_CHECK" -q "$QUIET_MODE"
+  log_msg -l "Blocks public access: $BLOCKS_PUBLIC_ACCESS_CHECK" -q "$QUIET_MODE"
+  log_msg -l "Bucket owner Full Control: $BUCKET_OWNER_FULL_CONTROL_CHECK" -q "$QUIET_MODE"
 done < <(echo "$BUCKETS")

--- a/bin/service/v1/container-access
+++ b/bin/service/v1/container-access
@@ -25,10 +25,10 @@ fi
 
 if ! command -v session-manager-plugin > /dev/null
 then
-  echo "This script requires the \`session-manager-plugin\` to be installed:"
-  echo "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-  echo "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:"
-  echo "softwareupdate --install-rosetta"
+  err "This script requires the \`session-manager-plugin\` to be installed"
+  log_info -l "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" -q "$QUIET_MODE"
+  log_info -l "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:" -q "$QUIET_MODE"
+  log_info -l "softwareupdate --install-rosetta" -q "$QUIET_MODE"
   exit 1
 fi
 
@@ -66,7 +66,7 @@ then
   usage
 fi
 
-echo "==> Finding container..."
+log_info -l "Finding container..." -q "$QUIET_MODE"
 
 CLUSTER="$INFRASTRUCTURE_NAME-$ENVIRONMENT"
 if [ -n "$CLUSTER_NAME" ]
@@ -86,7 +86,7 @@ CONTAINER_NAME_PREFIX="ecs-$(echo "$TASK_DEFINITION_ARN" | cut -d'/' -f2| sed -e
 CONTAINER_INSTANCE_DESCRIPTION=$(aws ecs describe-container-instances --cluster "$CLUSTER" --container-instance "$CONTAINER_INSTANCE_ARN")
 CONTAINER_INSTANCE_ID=$(echo "$CONTAINER_INSTANCE_DESCRIPTION" | jq -r '.containerInstances[0].ec2InstanceId')
 
-echo "==> Connecting to container $CONTAINER_NAME_PREFIX* on $CLUSTER cluster..."
+log_info -l "Connecting to container $CONTAINER_NAME_PREFIX* on $CLUSTER cluster..." -q "$QUIET_MODE"
 
 aws ssm start-session \
   --target "$CONTAINER_INSTANCE_ID" \

--- a/bin/service/v1/delete-environment-variable
+++ b/bin/service/v1/delete-environment-variable
@@ -54,9 +54,9 @@ then
   usage
 fi
 
-echo "==> deleting environment variable $KEY for $INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT ..."
+log_info -l "deleting environment variable $KEY for $INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT ..." -q "$QUIET_MODE"
 
 aws ssm delete-parameter \
   --name "/$INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT/$KEY"
 
-echo "==> deleted"
+log_info -l "deleted" -q "$QUIET_MODE"

--- a/bin/service/v1/deploy
+++ b/bin/service/v1/deploy
@@ -48,7 +48,7 @@ then
   usage
 fi
 
-echo "==> deploying $SERVICE_NAME in $ENVIRONMENT"
+log_info -l "deploying $SERVICE_NAME in $ENVIRONMENT" -q "$QUIET_MODE"
 
 aws codepipeline start-pipeline-execution --name "$INFRASTRUCTURE_NAME-$SERVICE_NAME-$ENVIRONMENT-build-and-deploy"
 

--- a/bin/service/v1/ecr-vulnerabilities
+++ b/bin/service/v1/ecr-vulnerabilities
@@ -56,7 +56,7 @@ fi
 
 REPOSITORY_NAME="$INFRASTRUCTURE_NAME-$SERVICE_NAME-$ENVIRONMENT"
 
-echo "==> Getting image vulnerabilities..."
+log_info -l "Getting image vulnerabilities..." -q "$QUIET_MODE"
 
 IMAGE_SCAN_FINDINGS=$(aws ecr describe-image-scan-findings --repository-name "$REPOSITORY_NAME" --image-id imageTag="$IMAGE_TAG" | jq -rc '.imageScanFindings.findings[]')
 

--- a/bin/service/v1/force-deployment
+++ b/bin/service/v1/force-deployment
@@ -51,14 +51,14 @@ if [[
   usage
 fi
 
-echo "==> Forcing new deployment for $SERVICE_NAME in $ENVIRONMENT"
+log_info -l "Forcing new deployment for $SERVICE_NAME in $ENVIRONMENT" -q "$QUIET_MODE"
 
 # This command updates the service to use the latest version of its task definition
 # and forces a new deployment.
 DEPLOYMENT=$(aws ecs update-service --service "$SERVICE_NAME" --task-definition "$ENVIRONMENT-$INFRASTRUCTURE_NAME-$SERVICE_NAME" --cluster "$INFRASTRUCTURE_NAME-$ENVIRONMENT" --force-new-deployment)
 
 if [ -n "$WATCH" ]; then
-  echo "==> Watching deployment status..."
+  log_info -l "Watching deployment status..." -q "$QUIET_MODE"
   EVENT_ID_REGEX=$(echo "$DEPLOYMENT" | jq -r '.service.events[] | .id' | tr '\n' '|' | sed 's/.$//')
   DEPLOYMENT_ID=$(echo "$DEPLOYMENT" | jq -r '.service.deployments[] | select(.status == "PRIMARY") | .id')
   STATUS=""
@@ -68,12 +68,12 @@ if [ -n "$WATCH" ]; then
     EVENT_ID_REGEX=$(echo "$SERVICE" | jq -r '.services[0].events[] | .id' | tr '\n' '|' | sed 's/.$//')
     STATUS=$(echo "$SERVICE" | jq -r --arg i "$DEPLOYMENT_ID" '.services[0].deployments[] | select(.id == $i) | .rolloutState')
     if [ -n "$EVENTS" ]; then
-      echo "$EVENTS" | jq -r '.message'
+      log_msg -l "$(echo "$EVENTS" | jq -r '.message')" -q "$QUIET_MODE"
     fi
-    echo "$SERVICE" | jq -r --arg i "$DEPLOYMENT_ID" '.services[0].deployments[] | select(.id == $i) | "\(.rolloutState) - Desired: \(.desiredCount), Pending: \(.pendingCount), Running: \(.runningCount)"'
+    log_msg -l "$(echo "$SERVICE" | jq -r --arg i "$DEPLOYMENT_ID" '.services[0].deployments[] | select(.id == $i) | "\(.rolloutState) - Desired: \(.desiredCount), Pending: \(.pendingCount), Running: \(.runningCount)"')" -q "$QUIET_MODE"
     sleep 10
   done
-  echo "==> Deployment complete."
+  log_info -l "Deployment complete." -q "$QUIET_MODE"
 else
-  echo "==> Deployment started."
+  log_info -l "Deployment started." -q "$QUIET_MODE"
 fi

--- a/bin/service/v1/get-environment-variable
+++ b/bin/service/v1/get-environment-variable
@@ -53,7 +53,7 @@ then
   usage
 fi
   
-echo "==> getting environment variable $KEY for $INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT"
+log_info -l "getting environment variable $KEY for $INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT" -q "$QUIET_MODE"
 
 aws ssm get-parameter --with-decryption \
   --name "/$INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT/$KEY" \

--- a/bin/service/v1/list-container-placement
+++ b/bin/service/v1/list-container-placement
@@ -49,7 +49,7 @@ then
   usage
 fi
 
-echo "==> Finding containers..."
+log_info -l "Finding containers..." -q "$QUIET_MODE"
 
 CLUSTER="$INFRASTRUCTURE_NAME-$ENVIRONMENT"
 if [ "$SERVICE_NAME" == "all" ]

--- a/bin/service/v1/list-domains
+++ b/bin/service/v1/list-domains
@@ -48,7 +48,7 @@ then
   usage
 fi
 
-echo "==> Finding domain names for $INFRASTRUCTURE_NAME $SERVICE_NAME ($ENVIRONMENT) ..."
+log_info -l "Finding domain names for $INFRASTRUCTURE_NAME $SERVICE_NAME ($ENVIRONMENT) ..." -q "$QUIET_MODE"
 
 CLOUDFRONT_DISTRIBUTION=$(aws cloudfront  list-distributions | jq -r --arg i "$INFRASTRUCTURE_NAME" --arg s "$SERVICE_NAME" --arg e "$ENVIRONMENT" '.DistributionList.Items[] | select(.DefaultCacheBehavior.TargetOriginId=="\($i)-\($s)-\($e)-default-origin")')
 

--- a/bin/service/v1/list-environment-variables
+++ b/bin/service/v1/list-environment-variables
@@ -48,7 +48,7 @@ then
   usage
 fi
 
-echo "==> Retrieving env vars for $INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT from Parameter Store..."
+log_info -l "Retrieving env vars for $INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT from Parameter Store..." -q "$QUIET_MODE"
 
 aws ssm get-parameters-by-path \
   --path "/$INFRASTRUCTURE_NAME/$SERVICE_NAME/$ENVIRONMENT/" \

--- a/bin/service/v1/list-pipelines
+++ b/bin/service/v1/list-pipelines
@@ -47,6 +47,6 @@ then
   usage
 fi
 
-echo "==> Listing pipelines for $INFRASTRUCTURE_NAME $SERVICE_NAME ($ENVIRONMENT) ..."
+log_info -l "Listing pipelines for $INFRASTRUCTURE_NAME $SERVICE_NAME ($ENVIRONMENT) ..." -q "$QUIET_MODE"
 
 aws codepipeline list-pipelines | jq -r --arg i "$INFRASTRUCTURE_NAME" --arg e "$ENVIRONMENT" --arg s "$SERVICE_NAME" '.pipelines[]| select(.name|test("^\($i)-\($s)-\($e)"))' | jq -r '.name'

--- a/bin/service/v1/pull-image
+++ b/bin/service/v1/pull-image
@@ -51,15 +51,15 @@ then
   usage
 fi
 
-echo "==> Finding Docker image..."
+log_info -l "Finding Docker image..." -q "$QUIET_MODE"
 
 IMAGE_URL=$(aws ecr describe-repositories --repository-name "$INFRASTRUCTURE_NAME-$SERVICE_NAME-$ENVIRONMENT" | jq -r '.repositories[0].repositoryUri')
 ECR_ENDPOINT=$(echo "$IMAGE_URL" | cut -d '/' -f1)
 
-echo "==> Logging into AWS ECR..."
+log_info -l "Logging into AWS ECR..." -q "$QUIET_MODE"
 
 aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_ENDPOINT" | sed 's/^/  /'
 
-echo "==> Pulling image $IMAGE_URL"
+log_info -l "Pulling image $IMAGE_URL" -q "$QUIET_MODE"
 
 docker pull "$IMAGE_URL" | sed 's/^/  /'

--- a/bin/service/v1/restart-containers
+++ b/bin/service/v1/restart-containers
@@ -48,7 +48,7 @@ then
   usage
 fi
 
-echo "==> restarting containers for $SERVICE_NAME in $ENVIRONMENT"
+log_info -l "restarting containers for $SERVICE_NAME in $ENVIRONMENT" -q "$QUIET_MODE"
 
 DEPLOYMENT=$(aws ecs update-service --service "$SERVICE_NAME" --task-definition "$ENVIRONMENT-$INFRASTRUCTURE_NAME-$SERVICE_NAME" --cluster "$INFRASTRUCTURE_NAME-$ENVIRONMENT" --force-new-deployment)
 EVENT_ID_REGEX=$(echo "$DEPLOYMENT" | jq -r '.service.events[] | .id' | tr '\n' '|' | sed 's/.$//')

--- a/bin/service/v1/run-container-command
+++ b/bin/service/v1/run-container-command
@@ -27,10 +27,10 @@ fi
 
 if ! command -v session-manager-plugin > /dev/null
 then
-  echo "This script requires the \`session-manager-plugin\` to be installed:"
-  echo "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-  echo "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:"
-  echo "softwareupdate --install-rosetta"
+  err "This script requires the \`session-manager-plugin\` to be installed"
+  log_info -l "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html" -q "$QUIET_MODE"
+  log_info -l "Also, If you are running an Mac M1 or above, you'll need to install Rosetta 2 by running:" -q "$QUIET_MODE"
+  log_info -l "softwareupdate --install-rosetta" -q "$QUIET_MODE"
   exit 1
 fi
 
@@ -76,7 +76,7 @@ then
   usage
 fi
 
-echo "==> Finding container..."
+log_info -l "Finding container..." -q "$QUIET_MODE"
 
 CLUSTER="$INFRASTRUCTURE_NAME-$ENVIRONMENT"
 if [ -n "$CLUSTER_NAME" ]
@@ -98,7 +98,7 @@ for TASK_ARN in $(echo "$TASKS" | jq -r '.taskArns|join(" ")'); do
 
   CONTAINER_INSTANCE_ID=$(echo "$CONTAINER_INSTANCE_DESCRIPTION" | jq -r '.containerInstances[0].ec2InstanceId')
 
-  echo "==> Running command on container $CONTAINER_NAME_PREFIX* on $CLUSTER cluster..."
+  log_info -l "Running command on container $CONTAINER_NAME_PREFIX* on $CLUSTER cluster..." -q "$QUIET_MODE"
 
   aws ssm start-session \
     --target "$CONTAINER_INSTANCE_ID" \

--- a/bin/service/v1/set-environment-variable
+++ b/bin/service/v1/set-environment-variable
@@ -24,7 +24,7 @@ set_envar() {
   KEY="$4"
   VALUE="$5"
 
-  echo "==> setting environment variable $4 for $1/$2/$3"
+  log_info -l "setting environment variable $4 for $1/$2/$3" -q "$QUIET_MODE"
 
   aws ssm put-parameter \
     --name "/$1/$2/$3/$4" \
@@ -90,7 +90,7 @@ fi
 
 if [[ ! "$KEY" =~ ^[a-zA-Z] ]]
 then
-  echo "ERROR: keys must start with an alphabetical (i.e. non-numeric) character"
+  err "keys must start with an alphabetical (i.e. non-numeric) character"
   usage
 fi
 

--- a/bin/service/v1/show-deployment-status
+++ b/bin/service/v1/show-deployment-status
@@ -48,7 +48,7 @@ then
   usage
 fi
 
-echo "==> deploying $SERVICE_NAME in $ENVIRONMENT"
+log_info -l "deploying $SERVICE_NAME in $ENVIRONMENT" -q "$QUIET_MODE"
 
 aws codepipeline get-pipeline-state --name "$INFRASTRUCTURE_NAME-$SERVICE_NAME-$ENVIRONMENT-build-and-deploy" |  jq -r '.stageStates[] | "Action: \(.actionStates[].actionName) \n Status: \(.actionStates[].latestExecution.status) \n Time:\(.actionStates[].latestExecution.lastStatusChange)  \n pipeline id: \(.latestExecution.pipelineExecutionId)\n"'
  

--- a/bin/service/v2/container-access
+++ b/bin/service/v2/container-access
@@ -58,7 +58,7 @@ then
   usage
 fi
 
-log_info -l "Finding container..." -q "$QUITE_MODE"
+log_info -l "Finding container..." -q "$QUIET_MODE"
 
 PROJECT_NAME="$(jq -r '.project_name' < "$CONFIG_SETUP_JSON_FILE")"
 CLUSTER="$PROJECT_NAME-$INFRASTRUCTURE_NAME-$ENVIRONMENT-infrastructure"

--- a/bin/service/v2/deploy
+++ b/bin/service/v2/deploy
@@ -48,7 +48,7 @@ then
   usage
 fi
 
-log_info -l "Deploying $SERVICE_NAME in $INFRASTRUCTURE_NAME $ENVIRONMENT"
+log_info -l "Deploying $SERVICE_NAME in $INFRASTRUCTURE_NAME $ENVIRONMENT" -q "$QUIET_MODE"
 
 PROJECT_NAME="$(jq -r '.project_name' < "$CONFIG_SETUP_JSON_FILE")"
 

--- a/bin/service/v2/set-environment-variables
+++ b/bin/service/v2/set-environment-variables
@@ -82,7 +82,7 @@ ENVIRONMENT_FILE_META_JSON="$(
 
 if [[ "$ENVIRONMENT_FILE_META_JSON" ]]
 then
-  log_info -l "Downloading and opening '$ENVIRONMENT_FILE_S3_URI' ..."
+  log_info -l "Downloading and opening '$ENVIRONMENT_FILE_S3_URI' ..." -q "$QUIET_MODE"
 
   "$APP_ROOT/bin/dalmatian" aws run-command \
     -p "$PROFILE" \
@@ -102,16 +102,16 @@ rm "$LOCAL_ENVIRONMENT_FILE-orig"
 
 if [[ -z "$DIFF" ]]
 then
-  log_info -l "No changes were made to the environment file, exiting ..."
+  log_info -l "No changes were made to the environment file, exiting ..." -q "$QUIET_MODE"
   rm "$LOCAL_ENVIRONMENT_FILE"
   exit 0
 fi
 
-log_info -l "The following changes will be made to the environment file:"
+log_info -l "The following changes will be made to the environment file:" -q "$QUIET_MODE"
 
-echo ""
-echo "$DIFF" | tail -n +3
-echo ""
+log_msg -l "" -q "$QUIET_MODE"
+log_msg -l "$(echo "$DIFF" | tail -n +3)" -q "$QUIET_MODE"
+log_msg -l "" -q "$QUIET_MODE"
 
 if ! yes_no "Do you want to upload these changes?" "y"
 then
@@ -119,7 +119,7 @@ then
   exit 0
 fi
 
-log_info -l "Uploading then removing $LOCAL_ENVIRONMENT_FILE ..."
+log_info -l "Uploading then removing $LOCAL_ENVIRONMENT_FILE ..." -q "$QUIET_MODE"
 
 "$APP_ROOT/bin/dalmatian" aws run-command \
   -p "$PROFILE" \

--- a/bin/terraform-dependencies/v2/get-tfvars
+++ b/bin/terraform-dependencies/v2/get-tfvars
@@ -41,10 +41,10 @@ fi
 log_info -l "Checking existance of tfvars bucket $TFVARS_BUCKET_NAME" -q "$QUIET_MODE"
 if aws s3api head-bucket --bucket "$TFVARS_BUCKET_NAME" > /dev/null 2>&1
 then
-  log_info -l "$TFVARS_BUCKET_NAME bucket exists ..." -q "$QUIET_MODE"
+  log_msg -l "$TFVARS_BUCKET_NAME bucket exists ..." -q "$QUIET_MODE"
   TFVARS_BUCKET_EXISTS=1
 else
-  log_info -l "$TFVARS_BUCKET_NAME bucket doesn't exist. Bucket will be created on first deployment." -q "$QUIET_MODE"
+  log_msg -l "$TFVARS_BUCKET_NAME bucket doesn't exist. Bucket will be created on first deployment." -q "$QUIET_MODE"
   TFVARS_BUCKET_EXISTS=0
 fi
 
@@ -136,10 +136,10 @@ fi
 
 if [[ "$TFVARS_BUCKET_EXISTS" == 0 || "$DEFAULT_TFVARS_EXISTS" == 0 ]]
 then
-  log_info -l "$DEAFULT_TFAVRS_FILE_NAME doesn't exist in tfvars S3 bucket." -q "$QUIET_MODE"
+  log_msg -l "$DEAFULT_TFAVRS_FILE_NAME doesn't exist in tfvars S3 bucket." -q "$QUIET_MODE"
   echo "project_name=\"$PROJECT_NAME\"" > "$CONFIG_TFVARS_DIR/$DEAFULT_TFAVRS_FILE_NAME"
   echo "aws_region=\"$DALMATIAN_ACCOUNT_DEFAULT_REGION\"" >> "$CONFIG_TFVARS_DIR/$DEAFULT_TFAVRS_FILE_NAME"
-  log_info -l "Created $CONFIG_TFVARS_DIR/$DEAFULT_TFAVRS_FILE_NAME" -q "$QUIET_MODE"
+  log_msg -l "Created $CONFIG_TFVARS_DIR/$DEAFULT_TFAVRS_FILE_NAME" -q "$QUIET_MODE"
 fi
 
 if [ "$GLOBAL_ACCOUNT_BOOSTRAP_TFVARS_FILE_EXISTS" == "0" ]

--- a/bin/util/v1/env
+++ b/bin/util/v1/env
@@ -27,7 +27,7 @@ while getopts "irh" opt; do
   esac
 done
 
->&2 echo "==> Getting AWS credentials for $INFRASTRUCTURE_NAME"
+log_info -l "Getting AWS credentials for $INFRASTRUCTURE_NAME" -q "$QUIET_MODE"
 if [ "$RAW" = "true" ]
 then
 env | grep AWS

--- a/bin/util/v1/ip-port-exposed
+++ b/bin/util/v1/ip-port-exposed
@@ -38,7 +38,7 @@ then
   usage
 fi
 
-echo "Searching ..."
+log_info -l "Searching ..." -q "$QUIET_MODE"
 
 PORTS_FILE="/tmp/$(date +%s).exposed_ports.txt"
 
@@ -47,9 +47,9 @@ aws ec2 describe-security-groups \
   --output json | jq -r '.[] | "\(.[0]) \(.[1]) \(.[2][].FromPort) \(.[2][].ToPort) \(.[2][].IpRanges | join(", "))"' > "$PORTS_FILE"
 
 if grep -E -v "80|443" < "$PORTS_FILE" ; then
-  echo "Exposed port found!"
+  log_info -l "Exposed port found!" -q "$QUIET_MODE"
 else
-  echo "No exposed ports found!"
+  log_info -l "No exposed ports found!" -q "$QUIET_MODE"
 fi
 
-echo "Finished!"
+log_info -l "Finished!" -q "$QUIET_MODE"

--- a/bin/util/v1/list-security-group-rules
+++ b/bin/util/v1/list-security-group-rules
@@ -22,5 +22,5 @@ while getopts "ih" opt; do
       ;;
   esac
 done
-log_info -l "Open Ports in the ${INFRASTRUCTURE_NAME} account"
+log_info -l "Open Ports in the ${INFRASTRUCTURE_NAME} account" -q "$QUIET_MODE"
 aws ec2 describe-security-groups | jq -r '.SecurityGroups[] | .GroupName as $group | .IpPermissions[] | .FromPort as $fromPort | .ToPort as $toPort | ([.IpRanges[]?.CidrIp, .UserIdGroupPairs[]?.GroupId, .Ipv6Ranges[]?.CidrIpv6] | map(select(. != null)) | .[] | "\($group),\($fromPort)-\($toPort),\(.)")'

--- a/bin/waf/v1/delete-ip-rule
+++ b/bin/waf/v1/delete-ip-rule
@@ -86,7 +86,7 @@ WAF_IP_SET_NAME="Dalmatian$ACTION$SOURCE_IP_LABEL"
 # e.g. DalmatianBlock123-123-123-123-32
 
 WAF_WEB_ACL_NAME="$INFRASTRUCTURE_NAME-$WAF_NAME-waf-$ENVIRONMENT-$WAF_NAME-acl"
-echo "==> Getting Web ACL '$WAF_WEB_ACL_NAME'..."
+log_info -l "Getting Web ACL '$WAF_WEB_ACL_NAME'..." -q "$QUIET_MODE"
 
 ACLS=$(aws wafv2 list-web-acls --scope "REGIONAL")
 ACL_SUMMARY=$(echo "$ACLS" | jq -r --arg acl_name "$WAF_WEB_ACL_NAME" '.WebACLs[] | select(.Name == $acl_name)')
@@ -103,7 +103,7 @@ echo "Found target Web ACL $ACL_ID"
 ACL_RULES=$(echo "$ACL" | jq -r '.WebACL.Rules')
 
 ACL_RULE_NAME="Custom$WAF_IP_SET_NAME"
-echo "==> Removing rule $ACL_RULE_NAME from Web ACL..."
+log_info -l "Removing rule $ACL_RULE_NAME from Web ACL..." -q "$QUIET_MODE"
 
 RULES=$(echo "$ACL_RULES" | jq -r --arg name "$ACL_RULE_NAME" 'del(.[] | select(.Name == $name))' | jq -c)
 
@@ -116,7 +116,7 @@ ACL=$(aws wafv2 update-web-acl --scope "REGIONAL" \
   --rules "$RULES"
 )
 
-echo "==> Getting IP Sets..."
+log_info -l "Getting IP Sets..." -q "$QUIET_MODE"
 IP_SETS=$(aws wafv2 list-ip-sets --scope "REGIONAL")
 IP_SET_SUMMARY=$(echo "$IP_SETS" | jq -r --arg ipset_name "$WAF_IP_SET_NAME" '.IPSets[] | select(.Name == $ipset_name)')
 IP_SET_ID=$(echo "$IP_SET_SUMMARY" | jq -r '.Id')
@@ -124,7 +124,7 @@ IP_SET_LOCK_TOKEN=$(echo "$IP_SET_SUMMARY" | jq -r '.LockToken')
 
 echo "Found target IP Set $IP_SET_ID"
 
-echo "==> Deleting IP Set '$WAF_IP_SET_NAME'..."
+log_info -l "Deleting IP Set '$WAF_IP_SET_NAME'..." -q "$QUIET_MODE"
 aws wafv2 delete-ip-set --scope "REGIONAL" \
   --name "$WAF_IP_SET_NAME" \
   --id "$IP_SET_ID" \

--- a/bin/waf/v1/list-blocked-requests
+++ b/bin/waf/v1/list-blocked-requests
@@ -83,7 +83,7 @@ ACL_SUMMARY=$(echo "$ACLS" | jq -r --arg acl_name "$WAF_WEB_ACL_NAME" '.WebACLs[
 ACL_ARN=$(echo "$ACL_SUMMARY" | jq -r '.ARN')
 ACL_ID=$(echo "$ACL_SUMMARY" | jq -r '.Id')
 
-echo "==> Querying for Blocked sampled requests..."
+log_info -l "Querying for Blocked sampled requests..." -q "$QUIET_MODE"
 
 ACL=$(aws wafv2 get-web-acl \
     --name "$WAF_WEB_ACL_NAME" \

--- a/bin/waf/v1/set-ip-rule
+++ b/bin/waf/v1/set-ip-rule
@@ -85,7 +85,7 @@ SOURCE_IP_LABEL=$(echo "$SOURCE_IP" | tr ./ -)
 WAF_IP_SET_NAME="Dalmatian$ACTION$SOURCE_IP_LABEL"
 # e.g. DalmatianBlock123-123-123-123-32
 
-echo "==> Creating new IP Set..."
+log_info -l "Creating new IP Set..." -q "$QUIET_MODE"
 IP_SET_SUMMARY=$(aws wafv2 create-ip-set --scope "REGIONAL" \
   --name "$WAF_IP_SET_NAME" \
   --ip-address-version "IPV4" \
@@ -95,7 +95,7 @@ IP_SET_ID=$(echo "$IP_SET_SUMMARY" | jq -r '.Id')
 echo "Created IP Set $IP_SET_ID"
 
 WAF_WEB_ACL_NAME="$INFRASTRUCTURE_NAME-$WAF_NAME-waf-$ENVIRONMENT-$WAF_NAME-acl"
-echo "==> Getting Web ACL '$WAF_WEB_ACL_NAME'..."
+log_info -l "Getting Web ACL '$WAF_WEB_ACL_NAME'..." -q "$QUIET_MODE"
 
 # WAF ACLs that we will need to attach the IP Set to
 ACLS=$(aws wafv2 list-web-acls --scope "REGIONAL")
@@ -120,7 +120,7 @@ PRIORITY_COUNT=$((ACL_RULES_COUNT + 1))
 
 echo "New rule will be given Priority $PRIORITY_COUNT"
 
-echo "==> Generating new ACL Rule..."
+log_info -l "Generating new ACL Rule..." -q "$QUIET_MODE"
 ACL_RULE_NAME="Custom$WAF_IP_SET_NAME"
 JSON_ACL_RULE=$(jq -n \
   --arg nm  "$ACL_RULE_NAME" \
@@ -152,7 +152,7 @@ echo "Created ACL Rule $ACL_RULE_NAME"
 
 RULES=$(echo "$ACL_RULES" | jq --argjson json "$JSON_ACL_RULE" -r '. += [$json]' | jq -c)
 
-echo "==> Adding new Rule to WAF Ruleset..."
+log_info -l "Adding new Rule to WAF Ruleset..." -q "$QUIET_MODE"
 ACL=$(aws wafv2 update-web-acl --scope "REGIONAL" \
   --name "$WAF_WEB_ACL_NAME" \
   --id "$ACL_ID" \

--- a/lib/bash-functions/log_msg.sh
+++ b/lib/bash-functions/log_msg.sh
@@ -2,14 +2,12 @@
 set -e
 set -o pipefail
 
-# Set up a handy log output function
+# Set up a handy log output function for plain messages
 #
-# @usage log_info -l 'Something happened :)'"
+# @usage log_msg -l 'Something happened :)'"
 # @param -l <log>  Any information to output
 # @param -q <0/1>  Quiet mode
-function log_info {
-  cyan='\033[0;36m'
-  clear='\033[0m'
+function log_msg {
   OPTIND=1
   QUIET_MODE=0
   while getopts "l:q:" opt; do
@@ -21,7 +19,7 @@ function log_info {
         QUIET_MODE="$OPTARG"
         ;;
       *)
-        echo "Invalid \`log_info\` function usage" >&2
+        echo "Invalid \`log_msg\` function usage" >&2
         exit 1
         ;;
     esac
@@ -31,7 +29,7 @@ function log_info {
 
   if [ "$QUIET_MODE" == "0" ]
   then
-    echo -e "${cyan}==>${clear} $LOG"
+    echo -e "$LOG"
   fi
 
   return 0

--- a/lib/bash-functions/resolve_aws_profile.sh
+++ b/lib/bash-functions/resolve_aws_profile.sh
@@ -10,6 +10,15 @@ set -o pipefail
 # @param -e <environment_name>     An infrastructure's environment name
 # @param -a <dalmatian_account>    A Dalmatian Account name
 function resolve_aws_profile {
+  local INFRASTRUCTURE_NAME
+  local ENVIRONMENT_NAME
+  local DALMATIAN_ACCOUNT
+  local ACCOUNT_INFRASTRUCTURES
+  local ACCOUNT_WORKSPACE
+  local PROFILE_NAME
+  local PROFILE_EXISTS
+  local PROFILE
+
   OPTIND=1
   while getopts "i:e:a:" opt; do
     case $opt in
@@ -24,7 +33,7 @@ function resolve_aws_profile {
         ;;
       *)
         echo "Invalid \`resolve_aws_profile\` function usage" >&2
-        exit 1
+        return 1
         ;;
     esac
   done
@@ -68,7 +77,7 @@ function resolve_aws_profile {
   then
     echo "Error: Profile does not exist for $INFRASTRUCTURE_NAME $ENVIRONMENT_NAME $DALMATIAN_ACCOUNT" >&2
     echo "Try running \`dalmatian aws generate-config\` first" >&2
-    exit 1
+    return 1
   fi
   echo "$PROFILE_NAME"
 }


### PR DESCRIPTION
This adds log_msg for when we want to output just the text but also want
quiet mode support.

It then refactors all scripts to use our logging functions instead of
echo.

Also adds quiet mode to the invocations of log_info which didnt have
it already.

Commands which arent wrapped by `dalmatian` now also source the
functions so they an use them.