### PR TITLE
Setup dependencies via brew bundle rather than non-existent script

### DIFF
--- a/README-in-development.md
+++ b/README-in-development.md
@@ -17,7 +17,7 @@ default identity source.
 1. Install the dependencies
 
    ```
-   ./bin/setup
+   brew bundle install
    ```
 
 1. Add the dalmatian-tools `bin` directory to your `$PATH`


### PR DESCRIPTION
There doesn't seem to be a `bin/setup` script in the `dalmatian-tools` repo.

(Alternatively, we could create one which contains `brew bundle install`)