### PR TITLE
Add an environment variable to skip the update failure prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,8 @@ source /path/to/dalmatian-tools/support/zsh-completion.sh
 
 - DALMATIAN_FZF_ENABLED
   Set to 0 to disable fzf support for interactive selections. Defaults to 1.
+
+- DALMATIAN_SKIP_UPDATE_PROMPT
+  Set to 1 to skip the update prompt when there are local changes or the current
+  version tag is newer than the remote. Useful when running a development
+  version.

--- a/bin/configure-commands/v2/update
+++ b/bin/configure-commands/v2/update
@@ -82,9 +82,12 @@ then
   then
     err "There may be a newer version of $GIT_DALMATIAN_TOOLS_OWNER/$GIT_DALMATIAN_TOOLS_REPO ($CURRENT_LOCAL_TAG -> $LATEST_REMOTE_TAG) but cant update!"
     err "This is because you have local changes in $APP_ROOT"
-    if ! yes_no "Do you want to continue without updating? (Y/N)" "N"
+    if [ "$DALMATIAN_SKIP_UPDATE_PROMPT" != "1" ]
     then
-      exit 1
+      if ! yes_no "Do you want to continue without updating? (Y/N)" "N"
+      then
+        exit 1
+      fi
     fi
     exit 0
   fi


### PR DESCRIPTION
This is so that when doing development you dont get interrupted because
an update has failed.