### PR TITLE
Enforce the use of a modern bash

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,5 @@
 brew "awscli"
+brew "bash"
 brew "colordiff"
 brew "coreutils"
 brew "gnupg"

--- a/bin/aurora/v1/count-sql-backups
+++ b/bin/aurora/v1/count-sql-backups
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Redirect command
 COMMAND_ARGS=( "${@:2}" )

--- a/bin/aurora/v1/create-database
+++ b/bin/aurora/v1/create-database
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aurora/v1/download-sql-backup
+++ b/bin/aurora/v1/download-sql-backup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Redirect command. Pass on all arguments except "aurora download-sql-backup"
 "$APP_ROOT/bin/dalmatian" rds download-sql-backup "${@:1}"

--- a/bin/aurora/v1/export-dump
+++ b/bin/aurora/v1/export-dump
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aurora/v1/get-root-password
+++ b/bin/aurora/v1/get-root-password
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aurora/v1/import-dump
+++ b/bin/aurora/v1/import-dump
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aurora/v1/list-databases
+++ b/bin/aurora/v1/list-databases
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aurora/v1/list-instances
+++ b/bin/aurora/v1/list-instances
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aurora/v1/set-root-password
+++ b/bin/aurora/v1/set-root-password
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aurora/v1/shell
+++ b/bin/aurora/v1/shell
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aurora/v1/start-sql-backup-to-s3
+++ b/bin/aurora/v1/start-sql-backup-to-s3
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aws/v1/assume-infrastructure-role
+++ b/bin/aws/v1/assume-infrastructure-role
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e
@@ -19,6 +19,8 @@ if ! command -v log_info > /dev/null; then
     fi
   done
 fi
+
+check_bash_version
 
 QUIET_MODE="${QUIET_MODE:-0}"
 

--- a/bin/aws/v1/awscli-version
+++ b/bin/aws/v1/awscli-version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e
@@ -19,6 +19,8 @@ if ! command -v log_info > /dev/null; then
     fi
   done
 fi
+
+check_bash_version
 
 QUIET_MODE="${QUIET_MODE:-0}"
 

--- a/bin/aws/v1/exec
+++ b/bin/aws/v1/exec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aws/v1/instance-shell
+++ b/bin/aws/v1/instance-shell
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires the `session-manager-plugin` to be installed:
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/bin/aws/v1/key-age
+++ b/bin/aws/v1/key-age
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aws/v1/mfa
+++ b/bin/aws/v1/mfa
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e
@@ -19,6 +19,8 @@ if ! command -v log_info > /dev/null; then
     fi
   done
 fi
+
+check_bash_version
 
 QUIET_MODE="${QUIET_MODE:-0}"
 

--- a/bin/aws/v2/account-init
+++ b/bin/aws/v2/account-init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aws/v2/exec
+++ b/bin/aws/v2/exec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aws/v2/generate-config
+++ b/bin/aws/v2/generate-config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aws/v2/list-profiles
+++ b/bin/aws/v2/list-profiles
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aws/v2/login
+++ b/bin/aws/v2/login
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/aws/v2/run-command
+++ b/bin/aws/v2/run-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/certificate/v1/create
+++ b/bin/certificate/v1/create
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/certificate/v1/delete
+++ b/bin/certificate/v1/delete
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -o pipefail

--- a/bin/certificate/v1/list
+++ b/bin/certificate/v1/list
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/ci/v1/deploy-build-logs
+++ b/bin/ci/v1/deploy-build-logs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/ci/v1/deploy-status
+++ b/bin/ci/v1/deploy-status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/cloudfront/v1/clear-cache
+++ b/bin/cloudfront/v1/clear-cache
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/cloudfront/v1/generate-basic-auth-password-hash
+++ b/bin/cloudfront/v1/generate-basic-auth-password-hash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/cloudfront/v1/logs
+++ b/bin/cloudfront/v1/logs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/cloudfront/v2/logs
+++ b/bin/cloudfront/v2/logs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/cloudtrail/v2/query
+++ b/bin/cloudtrail/v2/query
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/config/v1/list-environments
+++ b/bin/config/v1/list-environments
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 "$APP_ROOT/bin/dalmatian-refresh-config" > /dev/null
 usage() {
   echo "List environment names (e.g. 'staging' or 'prod') for an infrastructure"

--- a/bin/config/v1/list-infrastructures
+++ b/bin/config/v1/list-infrastructures
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 "$APP_ROOT/bin/dalmatian-refresh-config" > /dev/null
 
 usage() {

--- a/bin/config/v1/list-services
+++ b/bin/config/v1/list-services
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 "$APP_ROOT/bin/dalmatian-refresh-config" > /dev/null
 usage() {
   echo "List all services or list services for an infrastructure"

--- a/bin/config/v1/list-services-by-buildspec
+++ b/bin/config/v1/list-services-by-buildspec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 "$APP_ROOT/bin/dalmatian-refresh-config" > /dev/null
 

--- a/bin/config/v1/services-to-tsv
+++ b/bin/config/v1/services-to-tsv
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 "$APP_ROOT/bin/dalmatian-refresh-config" > /dev/null
 

--- a/bin/configure-commands/v1/login
+++ b/bin/configure-commands/v1/login
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e
@@ -19,6 +19,8 @@ if ! command -v log_info > /dev/null; then
     fi
   done
 fi
+
+check_bash_version
 
 QUIET_MODE="${QUIET_MODE:-0}"
 

--- a/bin/configure-commands/v2/setup
+++ b/bin/configure-commands/v2/setup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/configure-commands/v2/update
+++ b/bin/configure-commands/v2/update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/configure-commands/v2/version
+++ b/bin/configure-commands/v2/version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/dalmatian
+++ b/bin/dalmatian
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e
@@ -81,6 +81,8 @@ do
     export -f "${function_name?}"
   done < <(grep "^function" "$bash_function_file" | cut -d" " -f2)
 done
+
+check_bash_version
 
 if [ "${1:0:1}" == "-" ]
 then

--- a/bin/dalmatian-refresh-config
+++ b/bin/dalmatian-refresh-config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e
@@ -19,6 +19,8 @@ if ! command -v log_info > /dev/null; then
     fi
   done
 fi
+
+check_bash_version
 
 QUIET_MODE="${QUIET_MODE:-0}"
 

--- a/bin/deploy/v2/account-bootstrap
+++ b/bin/deploy/v2/account-bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/deploy/v2/delete-default-resources
+++ b/bin/deploy/v2/delete-default-resources
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/deploy/v2/infrastructure
+++ b/bin/deploy/v2/infrastructure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/deploy/v2/list-accounts
+++ b/bin/deploy/v2/list-accounts
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/deploy/v2/list-infrastructures
+++ b/bin/deploy/v2/list-infrastructures
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/ec2/v2/port-forward
+++ b/bin/ec2/v2/port-forward
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires the `session-manager-plugin` to be installed:
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/bin/ecs/v1/ec2-access
+++ b/bin/ecs/v1/ec2-access
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires the `session-manager-plugin` to be installed:
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/bin/ecs/v1/efs-restore
+++ b/bin/ecs/v1/efs-restore
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/ecs/v1/file-download
+++ b/bin/ecs/v1/file-download
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires the `session-manager-plugin` to be installed:
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/bin/ecs/v1/file-upload
+++ b/bin/ecs/v1/file-upload
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires the `session-manager-plugin` to be installed:
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/bin/ecs/v1/instance-refresh
+++ b/bin/ecs/v1/instance-refresh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/ecs/v1/remove-from-transfer-bucket
+++ b/bin/ecs/v1/remove-from-transfer-bucket
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/ecs/v1/upload-to-transfer-bucket
+++ b/bin/ecs/v1/upload-to-transfer-bucket
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/ecs/v2/ec2-access
+++ b/bin/ecs/v2/ec2-access
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires the `session-manager-plugin` to be installed:
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/bin/elasticache/v1/list-clusters
+++ b/bin/elasticache/v1/list-clusters
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/elasticache/v1/reboot
+++ b/bin/elasticache/v1/reboot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v1/count-sql-backups
+++ b/bin/rds/v1/count-sql-backups
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v1/create-database
+++ b/bin/rds/v1/create-database
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v1/download-sql-backup
+++ b/bin/rds/v1/download-sql-backup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v1/export-dump
+++ b/bin/rds/v1/export-dump
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v1/get-root-password
+++ b/bin/rds/v1/get-root-password
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v1/import-dump
+++ b/bin/rds/v1/import-dump
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v1/list-databases
+++ b/bin/rds/v1/list-databases
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v1/list-instances
+++ b/bin/rds/v1/list-instances
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v1/set-root-password
+++ b/bin/rds/v1/set-root-password
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v1/shell
+++ b/bin/rds/v1/shell
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v1/start-sql-backup-to-s3
+++ b/bin/rds/v1/start-sql-backup-to-s3
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v2/run-command
+++ b/bin/rds/v2/run-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/rds/v2/shell
+++ b/bin/rds/v2/shell
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/s3/v2/empty-and-delete-bucket
+++ b/bin/s3/v2/empty-and-delete-bucket
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/s3/v2/list-bucket-properties
+++ b/bin/s3/v2/list-bucket-properties
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/container-access
+++ b/bin/service/v1/container-access
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires the `session-manager-plugin` to be installed:
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/bin/service/v1/delete-environment-variable
+++ b/bin/service/v1/delete-environment-variable
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/deploy
+++ b/bin/service/v1/deploy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/deploy-build-logs
+++ b/bin/service/v1/deploy-build-logs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/deploy-status
+++ b/bin/service/v1/deploy-status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/ecr-vulnerabilities
+++ b/bin/service/v1/ecr-vulnerabilities
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/force-deployment
+++ b/bin/service/v1/force-deployment
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/get-environment-variable
+++ b/bin/service/v1/get-environment-variable
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/list-container-placement
+++ b/bin/service/v1/list-container-placement
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/list-domains
+++ b/bin/service/v1/list-domains
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/list-environment-variables
+++ b/bin/service/v1/list-environment-variables
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/list-pipelines
+++ b/bin/service/v1/list-pipelines
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/pull-image
+++ b/bin/service/v1/pull-image
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires the `session-manager-plugin` to be installed:
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/bin/service/v1/rename-environment-variable
+++ b/bin/service/v1/rename-environment-variable
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/restart-containers
+++ b/bin/service/v1/restart-containers
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/run-container-command
+++ b/bin/service/v1/run-container-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Requires the `session-manager-plugin` to be installed:
 # https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html

--- a/bin/service/v1/set-environment-variable
+++ b/bin/service/v1/set-environment-variable
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v1/show-deployment-status
+++ b/bin/service/v1/show-deployment-status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v2/container-access
+++ b/bin/service/v2/container-access
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v2/deploy
+++ b/bin/service/v2/deploy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v2/get-environment-variables
+++ b/bin/service/v2/get-environment-variables
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v2/list-services
+++ b/bin/service/v2/list-services
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/service/v2/set-environment-variables
+++ b/bin/service/v2/set-environment-variables
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/terraform-dependencies/v2/clean-tfvars-cache
+++ b/bin/terraform-dependencies/v2/clean-tfvars-cache
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/terraform-dependencies/v2/clone
+++ b/bin/terraform-dependencies/v2/clone
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/terraform-dependencies/v2/create-import-file
+++ b/bin/terraform-dependencies/v2/create-import-file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/terraform-dependencies/v2/get-tfvars
+++ b/bin/terraform-dependencies/v2/get-tfvars
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/terraform-dependencies/v2/initialise
+++ b/bin/terraform-dependencies/v2/initialise
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/terraform-dependencies/v2/link-import-file
+++ b/bin/terraform-dependencies/v2/link-import-file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/terraform-dependencies/v2/run-terraform-command
+++ b/bin/terraform-dependencies/v2/run-terraform-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/terraform-dependencies/v2/set-global-tfvars
+++ b/bin/terraform-dependencies/v2/set-global-tfvars
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/terraform-dependencies/v2/set-tfvars
+++ b/bin/terraform-dependencies/v2/set-tfvars
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/terraform-dependencies/v2/view-tfvars
+++ b/bin/terraform-dependencies/v2/view-tfvars
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/util/v1/env
+++ b/bin/util/v1/env
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo 'Get AWS credentials for an infrastructure'

--- a/bin/util/v1/exec
+++ b/bin/util/v1/exec
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
   echo "Run any cli command in an infrastructure or the main dalmatian account"

--- a/bin/util/v1/generate-four-words
+++ b/bin/util/v1/generate-four-words
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Words taken from https://github.com/hermitdave/FrequencyWords CC-BY-SA-4.0.
 # See README.md in the data/ directory for more details.

--- a/bin/util/v1/ip-port-exposed
+++ b/bin/util/v1/ip-port-exposed
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/util/v1/list-security-group-rules
+++ b/bin/util/v1/list-security-group-rules
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 
 usage() {

--- a/bin/utilities/v2/run-command
+++ b/bin/utilities/v2/run-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/waf/v1/cf-ip-block
+++ b/bin/waf/v1/cf-ip-block
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/waf/v1/delete-ip-rule
+++ b/bin/waf/v1/delete-ip-rule
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/waf/v1/list-blocked-requests
+++ b/bin/waf/v1/list-blocked-requests
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/bin/waf/v1/set-ip-rule
+++ b/bin/waf/v1/set-ip-rule
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/lib/bash-functions/append_import_block.sh
+++ b/lib/bash-functions/append_import_block.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/append_sso_config_file.sh
+++ b/lib/bash-functions/append_sso_config_file.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/append_sso_config_file_assume_role.sh
+++ b/lib/bash-functions/append_sso_config_file_assume_role.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/aws_epoch.sh
+++ b/lib/bash-functions/aws_epoch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/check_bash_version.sh
+++ b/lib/bash-functions/check_bash_version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+# This script is sourced by dalmatian and subcommands.
+# It ensures that a modern version of Bash is used.
+
+function check_bash_version() {
+  if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    echo "Error: Bash 4.0 or newer is required." >&2
+    echo "You appear to be running Bash ${BASH_VERSION}." >&2
+    echo "On macOS, you can install a modern version with: brew install bash" >&2
+    exit 1
+  fi
+}

--- a/lib/bash-functions/err.sh
+++ b/lib/bash-functions/err.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/install_session_manager.sh
+++ b/lib/bash-functions/install_session_manager.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/is_installed.sh
+++ b/lib/bash-functions/is_installed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/log_info.sh
+++ b/lib/bash-functions/log_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/log_msg.sh
+++ b/lib/bash-functions/log_msg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/pick_ecs_instance.sh
+++ b/lib/bash-functions/pick_ecs_instance.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/read_prompt_with_setup_default.sh
+++ b/lib/bash-functions/read_prompt_with_setup_default.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/resolve_aws_profile.sh
+++ b/lib/bash-functions/resolve_aws_profile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/resource_prefix_hash.sh
+++ b/lib/bash-functions/resource_prefix_hash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/warning.sh
+++ b/lib/bash-functions/warning.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/bash-functions/yes_no.sh
+++ b/lib/bash-functions/yes_no.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/lib/php-sql-munge.sh
+++ b/lib/php-sql-munge.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # exit on failures
 set -e

--- a/support/bash-completion.sh
+++ b/support/bash-completion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 _dalmatian_completion() {
   if ! command -v dalmatian > /dev/null
   then

--- a/support/zsh-completion.sh
+++ b/support/zsh-completion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 _dalmatian_completions_filter() {
   local words="$1"
   local cur=${COMP_WORDS[COMP_CWORD]}

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Check bash version is >= 4
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  echo "Tests require Bash 4.0 or newer." >&2
+  exit 1
+fi
+
 find ./bin -path ./bin/tmp -prune -o -type f -exec shellcheck -x {} +
 find ./support -type f -exec shellcheck -x {} +


### PR DESCRIPTION
MacOS ships with an older version of bash (3.2) which lacks many
features and has some quirks compared to modern versions of bash (4.0+).
This commit updates the shebangs in our bash scripts to use
`#!/usr/bin/env bash` which will use the version of bash found in the
user's environment, allowing users to use a modern version of bash if
they have it installed.

A test was also added to check that the version of bash being used is at
least 4.0, and the Brewfile was updated to include bash as a dependency,
so that users on MacOS will have a modern version of bash available when
they run `brew bundle install`.