### PR TITLE
Check and resolve first time running

### DIFF
--- a/README-in-development.md
+++ b/README-in-development.md
@@ -73,6 +73,13 @@ default identity source.
    Using either of these options will provide defaults for the prompts, so you
    should be able to press Enter for all values.
 
+1. Starting a dalmatian project
+
+   Run `dalmatian setup -b` or set the `DALMATIAN_BOOTSTRAP` environment variable to `true`
+   before running `dalmatian setup`. This will automatically bootstrap the main dalmatian account
+   after the initial setup. If you do not do this, you can always run `dalmatian deploy account-bootstrap`
+   at a later date to bootstrap the account.
+
 ## Usage
 
 ### Help

--- a/README-in-development.md
+++ b/README-in-development.md
@@ -75,11 +75,15 @@ default identity source.
 
 1. Starting a dalmatian project
 
-   Run `dalmatian setup -b` or set the `DALMATIAN_BOOTSTRAP` environment variable to `true`
-   before running `dalmatian setup` This will prompt you during the initial setup to run the
-   `dalmatian deploy account-bootstrap` command to set up the main dalmatian account. If you
-   do not do this, you can always run `dalmatian deploy account-bootstrap` at a later date
-   to bootstrap the account.
+   Run `dalmatian setup -b`, or set the `DALMATIAN_BOOTSTRAP` environment variable to `true`
+    before running `dalmatian setup`.
+    This prompts you during the initial setup to run the
+    `dalmatian deploy account-bootstrap` command to set up the main dalmatian account.
+    When bootstrap mode is enabled this way, setup currently passes `-d` to
+    `aws account-init`, which enables the prompt to delete default resources during
+    bootstrap.
+    If you do not do this during setup, you can always run
+    `dalmatian deploy account-bootstrap` at a later date to bootstrap the account.
 
 ## Usage
 

--- a/README-in-development.md
+++ b/README-in-development.md
@@ -76,9 +76,10 @@ default identity source.
 1. Starting a dalmatian project
 
    Run `dalmatian setup -b` or set the `DALMATIAN_BOOTSTRAP` environment variable to `true`
-   before running `dalmatian setup`. This will automatically bootstrap the main dalmatian account
-   after the initial setup. If you do not do this, you can always run `dalmatian deploy account-bootstrap`
-   at a later date to bootstrap the account.
+   before running `dalmatian setup` This will prompt you during the initial setup to run the
+   `dalmatian deploy account-bootstrap` command to set up the main dalmatian account. If you
+   do not do this, you can always run `dalmatian deploy account-bootstrap` at a later date
+   to bootstrap the account.
 
 ## Usage
 

--- a/bin/aws/v2/account-init
+++ b/bin/aws/v2/account-init
@@ -9,6 +9,7 @@ usage() {
   echo "  -h                     - help"
   echo "  -i <aws_account_id>    - AWS Account ID"
   echo "  -r <deefault_region>   - AWS Default region"
+  echo "  -d                     - Enable deletion of default resources"
   echo "  -n <account_name>      - A lower case hyphenated friendly name"
   echo "  -e <external>          - Configure as an 'External' AWS Account (An account not part of the SSO Org)"
   exit 1
@@ -19,9 +20,9 @@ if [ $# -eq 0 ]
 then
  usage
 fi
-
+ENABLE_DELETE=0
 ACCOUNT_EXTERNAL=0
-while getopts "i:r:n:eh" opt; do
+while getopts "i:r:n:edh" opt; do
   case $opt in
     i)
       AWS_ACCOUNT_ID=$OPTARG
@@ -34,6 +35,9 @@ while getopts "i:r:n:eh" opt; do
       ;;
     e)
       ACCOUNT_EXTERNAL=1
+      ;;
+    d)
+      ENABLE_DELETE=1
       ;;
     h)
       usage
@@ -121,12 +125,18 @@ fi
 
 "$APP_ROOT/bin/dalmatian" terraform-dependencies get-tfvars
 
+BOOTSTRAP_COMMAND_OPTION=""
+if [ "$ENABLE_DELETE" -eq 1 ]
+then
+  BOOTSTRAP_COMMAND_OPTION="-d"
+fi
+
 if [ "$ACCOUNT_NAME" != "dalmatian-main" ]
 then
   log_info -l "Running account bootstrap on the main Dalmatian account to upload tfvars ..." -q "$QUIET_MODE"
   DEFAULT_REGION="$(jq -r '.default_region' < "$CONFIG_SETUP_JSON_FILE")"
-  "$APP_ROOT/bin/dalmatian" deploy account-bootstrap -a "$MAIN_DALMATIAN_ACCOUNT_ID-$DEFAULT_REGION-dalmatian-main" -N
+  "$APP_ROOT/bin/dalmatian" deploy account-bootstrap -a "$MAIN_DALMATIAN_ACCOUNT_ID-$DEFAULT_REGION-dalmatian-main" -N "$BOOTSTRAP_COMMAND_OPTION"
 fi
 
 log_info -l "Running account bootstrap on $NEW_WORKSPACE_NAME" -q "$QUIET_MODE"
-"$APP_ROOT/bin/dalmatian" deploy account-bootstrap -a "$NEW_WORKSPACE_NAME"
+"$APP_ROOT/bin/dalmatian" deploy account-bootstrap -a "$NEW_WORKSPACE_NAME" "$BOOTSTRAP_COMMAND_OPTION"

--- a/bin/configure-commands/v2/setup
+++ b/bin/configure-commands/v2/setup
@@ -133,10 +133,15 @@ MAIN_DALMATIAN_ACCOUNT_ID=$(read_prompt_with_setup_default -p "Main dalmatian ac
 
 "$APP_ROOT/bin/dalmatian" aws account-init -i "$MAIN_DALMATIAN_ACCOUNT_ID" -r "$DEFAULT_REGION" -n "dalmatian-main"
 
-log_info -l "Setup complete!" -q "$QUIET_MODE"
-log_info -l "It is highly recommended to run the first account bootstrap for the main dalmatian account now, using \`dalmatian deploy account-bootstrap -a $MAIN_DALMATIAN_ACCOUNT_ID-$DEFAULT_REGION-dalmatian-main\`" -q "$QUIET_MODE"
-read -rp "Do you want to run this now? [y/n]: " DEPLOY_NOW
-if [[ "$DEPLOY_NOW" == "y" || "$DEPLOY_NOW" == "Y" ]]
+read -rp "Is this your first time setting up infrastructure with dalmatian? [y/n]: " FIRST_TIME
+if [[ "$FIRST_TIME" == "y" || "$FIRST_TIME" == "Y" ]]
 then
-  "$APP_ROOT/bin/dalmatian" deploy account-bootstrap -a "$MAIN_DALMATIAN_ACCOUNT_ID-$DEFAULT_REGION-dalmatian-main"
-fi
+  log_info -l "It is highly recommended to run the first account bootstrap for the main dalmatian account now, using \`dalmatian deploy account-bootstrap -a $MAIN_DALMATIAN_ACCOUNT_ID-$DEFAULT_REGION-dalmatian-main\`" -q "$QUIET_MODE"
+  read -rp "Do you want to run this now? [y/n]: " DEPLOY_NOW
+  if [[ "$DEPLOY_NOW" == "y" || "$DEPLOY_NOW" == "Y" ]]
+  then
+    "$APP_ROOT/bin/dalmatian" deploy account-bootstrap -a "$MAIN_DALMATIAN_ACCOUNT_ID-$DEFAULT_REGION-dalmatian-main"
+  fi
+fi  
+
+log_info -l "Setup complete!" -q "$QUIET_MODE"

--- a/bin/configure-commands/v2/setup
+++ b/bin/configure-commands/v2/setup
@@ -23,18 +23,27 @@ usage() {
   echo "Usage: dalmatian $(basename "$0") [OPTIONS]" 1>&2
   echo "  -h                     - help"
   echo "  -f <setup_filepath>    - Setup Filepath (Optional)"
+  echo "  -b                     - Enable bootstrap (Optional)"
   echo "  -u <setup_url>         - Setup URL (Optional)"
   exit 1
 }
+ENABLE_BOOTSTRAP=0
+if [ "$DALMATIAN_BOOTSTRAP" == "true" ]
+then
+  ENABLE_BOOTSTRAP=1
+fi
 
 SETUP_FILE_PATH=""
-while getopts "f:u:h" opt; do
+while getopts "f:u:bh" opt; do
   case $opt in
     f)
       SETUP_FILE_PATH="$OPTARG"
       ;;
     u)
       SETUP_FILE_URL="$OPTARG"
+      ;;
+    b)
+      ENABLE_BOOTSTRAP=1
       ;;
     h)
       usage
@@ -131,17 +140,23 @@ MAIN_DALMATIAN_ACCOUNT_ID=$(read_prompt_with_setup_default -p "Main dalmatian ac
 
 "$APP_ROOT/bin/dalmatian" aws generate-config
 
-"$APP_ROOT/bin/dalmatian" aws account-init -i "$MAIN_DALMATIAN_ACCOUNT_ID" -r "$DEFAULT_REGION" -n "dalmatian-main"
+INIT_COMMAND_OPTION=""
+if [ "$ENABLE_BOOTSTRAP" -eq 1 ]
+then
+  INIT_COMMAND_OPTION="-d"
+fi
+"$APP_ROOT/bin/dalmatian" aws account-init -i "$MAIN_DALMATIAN_ACCOUNT_ID" -r "$DEFAULT_REGION" -n "dalmatian-main" $INIT_COMMAND_OPTION
 
-read -rp "Is this your first time setting up infrastructure with dalmatian? [y/n]: " FIRST_TIME
-if [[ "$FIRST_TIME" == "y" || "$FIRST_TIME" == "Y" ]]
+if [ "$ENABLE_BOOTSTRAP" -eq 1 ]
 then
   log_info -l "It is highly recommended to run the first account bootstrap for the main dalmatian account now, using \`dalmatian deploy account-bootstrap -a $MAIN_DALMATIAN_ACCOUNT_ID-$DEFAULT_REGION-dalmatian-main\`" -q "$QUIET_MODE"
   read -rp "Do you want to run this now? [y/n]: " DEPLOY_NOW
   if [[ "$DEPLOY_NOW" == "y" || "$DEPLOY_NOW" == "Y" ]]
   then
     "$APP_ROOT/bin/dalmatian" deploy account-bootstrap -a "$MAIN_DALMATIAN_ACCOUNT_ID-$DEFAULT_REGION-dalmatian-main"
+  else
+    log_info -l "You can run this at a later date by running: \`dalmatian deploy account-bootstrap -a $MAIN_DALMATIAN_ACCOUNT_ID-$DEFAULT_REGION-dalmatian-main\`" -q "$QUIET_MODE"
   fi
-fi  
+fi
 
 log_info -l "Setup complete!" -q "$QUIET_MODE"

--- a/bin/deploy/v2/account-bootstrap
+++ b/bin/deploy/v2/account-bootstrap
@@ -10,6 +10,7 @@ usage() {
   echo "  -l                     - List accounts (shortcut to \`deploy list-accounts\`)"
   echo "  -a <dalmatian-account> - Dalmatian account name (Optional - By default all accounts will be cycled through)"
   echo "  -p                     - Run terraform plan rather than apply"
+  echo "  -d                     - Enable deletion of default resources"
   echo "  -N                     - Non-interactive mode (auto-approves terraform apply)"
   exit 1
 }
@@ -17,12 +18,13 @@ usage() {
 DALMATIAN_ACCOUNT=""
 NON_INTERACTIVE_MODE=0
 PLAN=0
+ENABLE_DELETE=0
 LIST_ACCOUNTS=0
 MAIN_DALMATIAN_ACCOUNT_ID="$(jq -r '.main_dalmatian_account_id' < "$CONFIG_SETUP_JSON_FILE")"
 DEFAULT_REGION="$(jq -r '.default_region' < "$CONFIG_SETUP_JSON_FILE")"
 MAIN_DALMATIAN_ACCOUNT="$MAIN_DALMATIAN_ACCOUNT_ID-$DEFAULT_REGION-dalmatian-main"
 
-while getopts "la:Nph" opt; do
+while getopts "la:Npdh" opt; do
   case $opt in
     l)
       LIST_ACCOUNTS=1
@@ -32,6 +34,9 @@ while getopts "la:Nph" opt; do
       ;;
     p)
       PLAN=1
+      ;;
+    d)
+      ENABLE_DELETE=1
       ;;
     N)
       NON_INTERACTIVE_MODE=1
@@ -97,9 +102,12 @@ do
     then
       if echo "$TERRAFORM_RESOURCES" | grep -q "aws_lambda_function.delete_default_resources\[0\]"
       then
-        if yes_no "Do you want to delete all the Default resources in the AWS account? [y/n]" "y"
+        if [ "$ENABLE_DELETE" -eq 1 ]
         then
-          "$APP_ROOT/bin/dalmatian" deploy delete-default-resources -a "$workspace"
+          if yes_no "Do you want to delete all the Default resources in the AWS account? [y/n]" "y"
+          then
+            "$APP_ROOT/bin/dalmatian" deploy delete-default-resources -a "$workspace"
+          fi
         fi
       fi
     fi

--- a/lib/bash-functions/log_msg.sh
+++ b/lib/bash-functions/log_msg.sh
@@ -8,6 +8,7 @@ set -o pipefail
 # @param -l <log>  Any information to output
 # @param -q <0/1>  Quiet mode
 function log_msg {
+  local OPTIND opt OPTARG
   OPTIND=1
   QUIET_MODE=0
   while getopts "l:q:" opt; do


### PR DESCRIPTION
Currently when running dalmatian setup you are always presented with the option to delete default resources via account-init calling account-bootstrap via the setup script and then you are then asked if you'd like to run the first account bootstrap before the setup is complete. This is fine if you are genuinely setting up dalmatian for the first time and need to bootstrap everything but in the majority of situations we don't need to do that. 

To resolve this the following changes have been made:

1. ENABLE_BOOTSTRAP=0, a DALMATIAN_BOOTSTRAP ENV variable check and a -b CLI option added to setup to allow multiple ways of telling dalmatian setup that you a would like to run the command and run the account bootstrap options. Otherwise defaults to 0 and you won't be presented with those choices. Setup will run ignoring those bootstrap commands.

2. ENABLE_DELETE=0 and a -d CLI option added to account-init and account-bootstrap to allow setup to call account-init and pass the -d option to enable the delete default resources in AWS choice.