### PR TITLE
Use tag_name instead of name when working out LATEST_REMOTE_TAG

### DIFF
--- a/bin/configure-commands/v2/update
+++ b/bin/configure-commands/v2/update
@@ -52,7 +52,7 @@ then
   exit 1
 fi
 
-LATEST_REMOTE_TAG=$(echo "$RELEASE_JSON" | jq -r '.name')
+LATEST_REMOTE_TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name')
 CURRENT_LOCAL_TAG=$(git -C "$APP_ROOT" describe --tags)
 LOCAL_CHANGES=$(git -C "$APP_ROOT" status -uno --porcelain)
 if [[


### PR DESCRIPTION
The `name` can be arbitrary and not necessarily a tag, whereas
`tag_name`
will always be the tag name of the release, which is what we want to
compare against our local tags.